### PR TITLE
Implements scores as nn.modules

### DIFF
--- a/seapig/model.py
+++ b/seapig/model.py
@@ -1,7 +1,5 @@
 """Selective Model Class."""
 
-from typing import override
-
 import torch
 
 from seapig.scores.base import ConfidenceScore
@@ -20,9 +18,9 @@ class SelectiveModel(torch.nn.Module):
         self.model = model
         self.csf = confidence_score
 
-    @override
     @torch.inference_mode()
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        """Implement forward pass with confidence score selection."""
         preds: torch.Tensor | dict[str, torch.Tensor] = self.model(x)
         if isinstance(preds, torch.Tensor):
             preds = {"predictions": preds}

--- a/seapig/scores/base.py
+++ b/seapig/scores/base.py
@@ -6,7 +6,7 @@ from typing import Any, override
 import torch
 
 
-class ConfidenceScore(ABC):
+class ConfidenceScore(torch.nn.Module, ABC):
     """Abstract Base Class for Confidence Scores.
 
     Confidence scores quantify the deviation of query samples from the training
@@ -42,12 +42,14 @@ class ConfidenceScore(ABC):
     train_required: bool = False
     calibrated: bool = False
     cal_required: bool = False
-    scores: torch.Tensor | None = None
-    threshold: torch.Tensor | None = None
+    scores: torch.Tensor | None
+    threshold: torch.Tensor | None
     ident: str
 
     def __init__(self) -> None:
-        return
+        super().__init__()
+        self.register_buffer("threshold", None)
+        self.register_buffer("scores", None, persistent=False)
 
     def requires_training(self) -> bool:
         """Return boolean indicating if the score requires training."""
@@ -78,28 +80,17 @@ class ConfidenceScore(ABC):
         return self.threshold
 
     @abstractmethod
-    def to(self, device: str | torch.device = "cpu") -> None:
-        """Move all tensors to the specified device."""
-        pass
-
-    @staticmethod
-    def _to(
-        tensor: torch.Tensor | None, device: str | torch.device = "cpu"
-    ) -> torch.Tensor | None:
-        if tensor is None:
-            return None
-        return tensor.to(device=device)
-
-    @abstractmethod
     def set_threshold(self, q: float = 0.99) -> None:
         """Set a threshold based on a specific quantile on the available scores.
-        
+
         Samples with scores higher than this threshold are excluded from prediction.
         """
         pass
 
     @abstractmethod
-    def fit(self, X: Any, Y: Any | None, *args: Any, **kwargs: Any) -> None:
+    def fit(
+        self, X: torch.Tensor, Y: torch.Tensor | None, *args: Any, **kwargs: Any
+    ) -> None:
         """Fit a confidence score.
 
         Here, `X` is used as training samples to fit the downstream method,
@@ -111,7 +102,7 @@ class ConfidenceScore(ABC):
     @abstractmethod
     def score(self, X: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         """Calculate the confidence score for a tensor of samples.
-        
+
         Returns scores where low values indicate likely inliers and high values
         indicate likely outliers.
         """
@@ -122,7 +113,7 @@ class ConfidenceScore(ABC):
         self, X: torch.Tensor, *args: Any, **kwargs: Any
     ) -> dict[str, torch.Tensor]:
         """Select samples for prediction based on their confidence score.
-        
+
         Samples with scores lower than the threshold are selected for prediction,
         while samples with scores higher than the threshold are excluded.
         """
@@ -149,12 +140,11 @@ class RandomScore(ConfidenceScore):
 
     train_required: bool = False
     cal_required: bool = False
-    threshold: torch.Tensor | None = torch.Tensor([0.099])
-    ident = "random"
+    threshold: torch.Tensor | None = torch.Tensor([0.99])
+    ident: str = "random"
 
-    @override
-    def to(self, device: str | torch.device = "cpu") -> None:
-        self.threshold = self._to(self.threshold, device=device)
+    def __init__(self) -> None:
+        super().__init__()
 
     @override
     def fit(

--- a/seapig/scores/base.py
+++ b/seapig/scores/base.py
@@ -140,11 +140,11 @@ class RandomScore(ConfidenceScore):
 
     train_required: bool = False
     cal_required: bool = False
-    threshold: torch.Tensor | None = torch.Tensor([0.99])
     ident: str = "random"
 
     def __init__(self) -> None:
         super().__init__()
+        self.set_threshold(q=0.99)
 
     @override
     def fit(

--- a/seapig/scores/embed.py
+++ b/seapig/scores/embed.py
@@ -56,7 +56,6 @@ class EmbeddingScore(ConfidenceScore, ABC):
         self.exp_var = exp_var
         self.pca = None
         if self.exp_var:
-            print(self.exp_var)
             self.pca = TensorPCA(exp_var=exp_var)
         self.register_buffer("ref_embeddings", None)
         self.register_buffer("cal_embeddings", None, persistent=False)
@@ -283,7 +282,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
             outdir=outdir,
             prefix=prefix,
         )
-        self = self.to(device=self.ref_embeddings.device)
+        self.to(device=self.ref_embeddings.device)
 
     @override
     def set_threshold(self, q: float = 0.99) -> None:

--- a/seapig/scores/embed.py
+++ b/seapig/scores/embed.py
@@ -48,26 +48,18 @@ class EmbeddingScore(ConfidenceScore, ABC):
     ref_embeddings: torch.Tensor | None
     cal_embeddings: torch.Tensor | None
     train_required: bool = True
-    cal_required: bool = True
-    scores: torch.Tensor | None
-    pca: TensorPCA | None = None
+    pca: TensorPCA | None
+    exp_var: float | bool
 
     def __init__(self, exp_var: float | bool = False) -> None:
         super().__init__()
-        self.ref_embeddings = None
-        self.cal_embeddings = None
-        self.scores = None
         self.exp_var = exp_var
-
-    def to(self, device: str | torch.device = "cpu") -> None:
-        """Put all tensors to the specified device."""
-        self.ref_embeddings = self._to(self.ref_embeddings, device=device)
-        self.cal_embeddings = self._to(self.cal_embeddings, device=device)
-        self.scores = self._to(self.scores, device=device)
-        self.threshold = self._to(self.threshold, device=device)
-        self.cal_embeddings = self._to(self.cal_embeddings, device=device)
-        if self.pca is not None:
-            self.pca.to(device=device)
+        self.pca = None
+        if self.exp_var:
+            print(self.exp_var)
+            self.pca = TensorPCA(exp_var=exp_var)
+        self.register_buffer("ref_embeddings", None)
+        self.register_buffer("cal_embeddings", None, persistent=False)
 
     @staticmethod
     def _setup_path(
@@ -196,10 +188,11 @@ class EmbeddingScore(ConfidenceScore, ABC):
         return embs
 
     def _fit_pca(self) -> None:
+        if not self.exp_var:
+            return
         assert self.ref_embeddings is not None
-        self.pca = TensorPCA(exp_var=self.exp_var)
+        assert isinstance(self.pca, TensorPCA)
         self.pca.fit(self.ref_embeddings)
-        self.pca.to(device=self.ref_embeddings.device)
 
     @override
     def fit(
@@ -290,7 +283,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
             outdir=outdir,
             prefix=prefix,
         )
-        self.to(device=self.ref_embeddings.device)
+        self = self.to(device=self.ref_embeddings.device)
 
     @override
     def set_threshold(self, q: float = 0.99) -> None:

--- a/seapig/scores/knn.py
+++ b/seapig/scores/knn.py
@@ -42,22 +42,20 @@ class KNNScore(EmbeddingScore, ABC):
     """
 
     k: int = 1
-    train_required: bool = True
-    cal_required: bool = True
-    cal_embeddings: torch.Tensor | None = None
-    threshold: torch.Tensor | None = None
-    scores: torch.Tensor | None = None
-    index: faiss.IndexFlatL2 | None = None
+    index: faiss.Index | None = None
+    ref_embeddings: torch.Tensor
+    cal_embeddings: torch.Tensor | None
 
     def __init__(
         self, k: int = 1, stat: str = "max", exp_var: float | bool = False
     ) -> None:
-        super().__init__()
+        super().__init__(exp_var=exp_var)
         assert stat in ["max", "mean", "median", "min"]
-        self.stat = stat
+        self.stat: str = stat
         self.k = k
-        self.exp_var = exp_var
-        self.ident = f"{self.ident}-k{self.k}-{'full' if exp_var else 'pca'}"
+        self.ident: str = (
+            f"{self.ident}-k{self.k}-{'full' if exp_var else 'pca'}"
+        )
 
     @override
     def fit(
@@ -139,7 +137,7 @@ class KNNScore(EmbeddingScore, ABC):
     def _fit_impl(self, q: float | None = None) -> None:
         """Fit implementation."""
         assert self.ref_embeddings is not None
-        self.to(device=self.ref_embeddings.device)
+        self = self.to(device=self.ref_embeddings.device)
         if self.cal_required:
             assert self.cal_embeddings is not None
 
@@ -253,7 +251,7 @@ class EuclideanScore(KNNScore):
     """
 
     k: int
-    ident = "euclidean"
+    ident: str = "euclidean"
 
     def __init__(
         self, k: int = 1, stat: str = "max", exp_var: float | bool = False
@@ -287,6 +285,7 @@ class CosineScore(KNNScore):
     The cosine distance is calculated as (1 - cosine_similarity), with a range
     of [0, 2] where 0 indicates identical vectors, 1 indicates orthogonal
     vectors, and 2 indicates opposite vectors.
+
     Parameters
     ----------
     k:
@@ -311,7 +310,7 @@ class CosineScore(KNNScore):
     """
 
     k: int = 1
-    ident = "cosine"
+    ident: str = "cosine"
 
     def __init__(
         self, k: int = 1, stat: str = "max", exp_var: float | bool = False
@@ -346,7 +345,7 @@ class MahalanobisScore(KNNScore):
     Computes Mahalanobis distance-based confidence scores where low scores indicate
     samples similar to the training distribution (likely inliers) and high scores
     indicate samples deviating from the training distribution (likely outliers).
-    
+
     The Mahalanobis distance accounts for correlations in the training data by
     using the covariance matrix of the training embeddings.
 
@@ -375,16 +374,13 @@ class MahalanobisScore(KNNScore):
 
     k: int
     vi_zero: torch.Tensor
-    train_required: bool = True
-    cal_required: bool = True
-    threshold: torch.Tensor | None = None
-    scores: torch.Tensor
-    ident = "mahalanobis"
+    ident: str = "mahalanobis"
 
     def __init__(
         self, k: int = 1, stat: str = "max", exp_var: float | bool = False
     ) -> None:
         super().__init__(k=k, stat=stat, exp_var=exp_var)
+        self.register_buffer("vi_zero", None)
 
     @override
     def _setup_index(self) -> None:

--- a/seapig/scores/knn.py
+++ b/seapig/scores/knn.py
@@ -43,7 +43,6 @@ class KNNScore(EmbeddingScore, ABC):
 
     k: int = 1
     index: faiss.Index | None = None
-    ref_embeddings: torch.Tensor
     cal_embeddings: torch.Tensor | None
 
     def __init__(
@@ -137,7 +136,7 @@ class KNNScore(EmbeddingScore, ABC):
     def _fit_impl(self, q: float | None = None) -> None:
         """Fit implementation."""
         assert self.ref_embeddings is not None
-        self = self.to(device=self.ref_embeddings.device)
+        self.to(device=self.ref_embeddings.device)
         if self.cal_required:
             assert self.cal_embeddings is not None
 

--- a/seapig/scores/pca.py
+++ b/seapig/scores/pca.py
@@ -35,9 +35,10 @@ class PCAScore(EmbeddingScore):
         gamma: float | None = 3.0,
         M: int | None = 4096,
     ) -> None:
-        super().__init__(exp_var=exp_var)
-        self.pca = TensorPCA(exp_var=exp_var, gamma=gamma, M=M)
-        self.ident = f"{self.ident}-{exp_var}"
+        super().__init__(exp_var=False)
+        self.exp_var = exp_var
+        self.pca = TensorPCA(exp_var=self.exp_var, gamma=gamma, M=M)
+        self.ident = f"{self.ident}-{self.exp_var}"
 
     @override
     def fit(

--- a/seapig/scores/pca.py
+++ b/seapig/scores/pca.py
@@ -7,6 +7,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from seapig.scores.embed import EmbeddingScore
+from seapig.scores.utils import TensorPCA
 
 
 class PCAScore(EmbeddingScore):
@@ -34,15 +35,16 @@ class PCAScore(EmbeddingScore):
         gamma: float | None = 3.0,
         M: int | None = 4096,
     ) -> None:
-        super().__init__()
-        self.exp_var = exp_var
-        self.gamma = gamma
-        self.M = M
+        super().__init__(exp_var=exp_var)
+        self.pca = TensorPCA(exp_var=exp_var, gamma=gamma, M=M)
         self.ident = f"{self.ident}-{exp_var}"
 
     @override
     def fit(
-        self, X: torch.Tensor, Y: torch.Tensor | None, q: bool | float = False
+        self,
+        X: torch.Tensor,
+        Y: torch.Tensor | None = None,
+        q: bool | float = False,
     ) -> None:
         """Train a confidence score based on sample embeddings.
 
@@ -70,7 +72,6 @@ class PCAScore(EmbeddingScore):
             remove outliers from the training distribution. Defaults to `False`.
         """
         super().fit(X=X, Y=Y)
-        self._fit_pca()
         self._fit_impl(q=q)
 
     @override
@@ -169,5 +170,5 @@ class PCAScore(EmbeddingScore):
         """
         assert self.pca is not None
         self.to(device=X.device)
-        _, score = self.pca.reconstruct(X)
-        return score
+        _, error = self.pca.reconstruct(X)
+        return error

--- a/seapig/scores/pyod.py
+++ b/seapig/scores/pyod.py
@@ -1,9 +1,10 @@
 """Confidence score based on an arbitrary PyOD model."""
 
 from pathlib import Path
-from typing import Any, override
+from typing import override
 
 import torch
+from pyod.models.base import BaseDetector
 from torch.utils.data import DataLoader
 
 from seapig.scores.embed import EmbeddingScore
@@ -38,17 +39,16 @@ class PyODScore(EmbeddingScore):
         than this threshold are excluded from prediction. Defaults to `None`.
     """
 
-    trained: bool = False
     train_required: bool = True
-    calibrated: bool = False
     cal_required: bool = True
-    cal_embeddings: torch.Tensor | None = None
-    detector: Any
-    ident = "pyod"
+    detector: BaseDetector
+    ident: str = "pyod"
 
-    def __init__(self, detector: Any, exp_var: float | bool = False) -> None:
+    def __init__(
+        self, detector: BaseDetector, exp_var: float | bool = False
+    ) -> None:
+        super().__init__(exp_var=exp_var)
         self.detector = detector
-        self.exp_var = exp_var
         self.ident = f"{self.ident}-{detector.__class__.__name__}"
 
     @override

--- a/seapig/scores/utils.py
+++ b/seapig/scores/utils.py
@@ -1,9 +1,12 @@
 """Utilities accessed by several modules."""
 
+from typing import final
+
 import torch
 
 
-class TensorPCA:
+@final
+class TensorPCA(torch.nn.Module):
     """Tensor based PCA with L2 normalized inputs.
 
     See https://arxiv.org/pdf/2505.15284.
@@ -14,28 +17,28 @@ class TensorPCA:
     u: torch.Tensor
     s: torch.Tensor
     s_acc: torch.Tensor
-    q: int
     u_q: torch.Tensor
     u_q_dot: torch.Tensor
+    q: int = 1
 
     def __init__(
         self,
         exp_var: float = 0.90,
-        gamma: int | None = None,
+        gamma: float | None = None,
         M: int | None = None,
     ):
-        self.exp_var = exp_var
+        super().__init__()
+        assert exp_var > 0.0 and exp_var <= 1.0
+        self.exp_var: float = exp_var
         self.gamma = gamma
         self.M = M
 
-    def to(self, device: str | torch.device = "cpu") -> None:
-        """Put all tensors to the specified device."""
-        self.mu = self.mu.to(device=device)
-        self.u = self.u.to(device=device)
-        self.s = self.s.to(device=device)
-        self.s_acc = self.s_acc.to(device=device)
-        self.u_q = self.u_q.to(device=device)
-        self.u_q_dot = self.u_q_dot.to(device=device)
+        self.register_buffer("mu", torch.tensor([]))
+        self.register_buffer("u", torch.tensor([]))
+        self.register_buffer("s", torch.tensor([]))
+        self.register_buffer("s_acc", torch.tensor([]))
+        self.register_buffer("u_q", torch.tensor([]))
+        self.register_buffer("u_q_dot", torch.tensor([]))
 
     @staticmethod
     def _l2_normalize(X: torch.Tensor) -> torch.Tensor:
@@ -68,6 +71,7 @@ class TensorPCA:
 
     def fit(self, X: torch.Tensor, Y: None = None) -> None:
         """Fitting the PCA based on an input tensor."""
+        assert X is not None
         X = self._l2_normalize(X)
         X = self._rff(X, gamma=self.gamma, M=self.M)
         self.mu = X.mean(dim=0)
@@ -86,6 +90,7 @@ class TensorPCA:
 
     def predict(self, X: torch.Tensor) -> torch.Tensor:
         """Reduce an input to its principal components."""
+        assert isinstance(X, torch.Tensor)
         X = self._preprocess(X)
         X = X @ self.u_q
         return X

--- a/seapig/scores/utils.py
+++ b/seapig/scores/utils.py
@@ -33,12 +33,12 @@ class TensorPCA(torch.nn.Module):
         self.gamma = gamma
         self.M = M
 
-        self.register_buffer("mu", torch.tensor([]))
-        self.register_buffer("u", torch.tensor([]))
-        self.register_buffer("s", torch.tensor([]))
-        self.register_buffer("s_acc", torch.tensor([]))
-        self.register_buffer("u_q", torch.tensor([]))
-        self.register_buffer("u_q_dot", torch.tensor([]))
+        self.register_buffer("mu", None)
+        self.register_buffer("u", None)
+        self.register_buffer("s", None)
+        self.register_buffer("s_acc", None)
+        self.register_buffer("u_q", None)
+        self.register_buffer("u_q_dot", None)
 
     @staticmethod
     def _l2_normalize(X: torch.Tensor) -> torch.Tensor:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -34,7 +34,7 @@ class DummyEmbedding(EmbeddingScore):
         return X.sum(dim=1)
 
 
-def test_pca_correctly_initialized_with_exp_var():
+def test_pca_correctly_initialized_with_exp_var() -> None:
     e = DummyEmbedding(exp_var=False)
     assert e.pca is None
     assert not e.exp_var
@@ -44,7 +44,7 @@ def test_pca_correctly_initialized_with_exp_var():
     assert e.exp_var == 0.5
 
 
-def test_setup_path_creates_dir_and_returns_path(tmp_path):
+def test_setup_path_creates_dir_and_returns_path(tmp_path) -> None:
     outdir = tmp_path / "subdir"
     path = EmbeddingScore._setup_path(outdir=outdir, prefix="myprefix")
     assert path is not None
@@ -66,7 +66,7 @@ def test_check_model_valid_and_invalid():
         EmbeddingScore._check_model(DummyBadSignature())
 
 
-def test_write_and_load_parquet_roundtrip(tmp_path):
+def test_write_and_load_parquet_roundtrip(tmp_path) -> None:
     x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
     path = tmp_path / "embs.parquet"
     EmbeddingScore._write_parquet(x, path)
@@ -76,7 +76,7 @@ def test_write_and_load_parquet_roundtrip(tmp_path):
     assert torch.allclose(y, x)
 
 
-def test_embed_errors_and_success():
+def test_embed_errors_and_success() -> None:
     model = DummyModel()
     # dict missing "image" should raise KeyError
     with pytest.raises(KeyError):
@@ -98,7 +98,7 @@ def test_embed_errors_and_success():
     assert out.shape == (2, 2)
 
 
-def test_embed_dl_concatenates_batches():
+def test_embed_dl_concatenates_batches() -> None:
     model = DummyModel()
     # use TensorDataset so DataLoader yields (B,D)
     samples = torch.tensor([[float(i), float(i) + 0.1] for i in range(4)])
@@ -115,7 +115,7 @@ def test_embed_dl_concatenates_batches():
     assert embs.shape[1] == 2
 
 
-def test_embed_from_dict_errors_and_saves(tmp_path):
+def test_embed_from_dict_errors_and_saves(tmp_path) -> None:
     model = DummyModel()
     samples = torch.tensor([[1.0, 2.0]])
     dataset = TensorDataset(samples)
@@ -150,14 +150,14 @@ def test_embed_from_dict_errors_and_saves(tmp_path):
     assert expected.exists()
 
 
-def test_fit_pca_sets_pca_and_device():
+def test_fit_pca_sets_pca_and_device() -> None:
     e = DummyEmbedding(exp_var=0.5)
     e.ref_embeddings = torch.randn(10, 5)
     e._fit_pca()
     assert isinstance(e.pca, TensorPCA) or e.pca is not None
 
 
-def test_set_threshold_and_select_behavior():
+def test_set_threshold_and_select_behavior() -> None:
     e = DummyEmbedding()
     # avoid train/cal checks
     e.train_required = False
@@ -197,7 +197,7 @@ class MinimalEmbedding(EmbeddingScore):
         return X.sum(dim=1)
 
 
-def test_fit_dl_model_without_embed_raises(tmp_path):
+def test_fit_dl_model_without_embed_raises(tmp_path) -> None:
     class NoEmbedModel(torch.nn.Module):
         pass
 
@@ -211,7 +211,7 @@ def test_fit_dl_model_without_embed_raises(tmp_path):
         s.fit_dl(model=NoEmbedModel(), loaders=loaders)
 
 
-def test_score_dl_writes_and_returns_tensor(tmp_path):
+def test_score_dl_writes_and_returns_tensor(tmp_path) -> None:
     class IdentityModel(torch.nn.Module):
         def embed(self, x):
             if isinstance(x, dict):
@@ -238,7 +238,7 @@ def test_score_dl_writes_and_returns_tensor(tmp_path):
     assert (tmp_path / "pfx.parquet").exists()
 
 
-def test_select_dl_respects_threshold(tmp_path):
+def test_select_dl_respects_threshold(tmp_path) -> None:
     class IdentityModel(torch.nn.Module):
         def embed(self, x):
             if isinstance(x, dict):

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -34,6 +34,16 @@ class DummyEmbedding(EmbeddingScore):
         return X.sum(dim=1)
 
 
+def test_pca_correctly_initialized_with_exp_var():
+    e = DummyEmbedding(exp_var=False)
+    assert e.pca is None
+    assert not e.exp_var
+
+    e = DummyEmbedding(exp_var=0.5)
+    assert isinstance(e.pca, TensorPCA)
+    assert e.exp_var == 0.5
+
+
 def test_setup_path_creates_dir_and_returns_path(tmp_path):
     outdir = tmp_path / "subdir"
     path = EmbeddingScore._setup_path(outdir=outdir, prefix="myprefix")

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -81,7 +81,7 @@ def test_pca_score_fit_and_score_basic() -> None:
     cal = torch.randn(n_cal, dim)
     qs = torch.randn(5, dim)
 
-    score = PCAScore(exp_var=0.90)
+    score = PCAScore(exp_var=0.90, M=16)
     # supply embeddings directly
     score.fit(train, cal)
     # check trained & calibrated flags
@@ -95,21 +95,9 @@ def test_pca_score_fit_and_score_basic() -> None:
 def test_q_trimming_in_pca_score_reduces_references() -> None:
     n = 200
     refs = torch.randn(n, 6)
-    score = PCAScore(exp_var=0.90)
+    score = PCAScore(exp_var=0.90, gamma=1.0, M=32)
     score.cal_required = False
     score.ref_embeddings = refs
     original = score.ref_embeddings.shape[0]
     score._fit_impl(q=0.5)
     assert score.ref_embeddings.shape[0] < original
-
-
-def test_score_device_consistency() -> None:
-    """score should work when moved between devices (cpu only environment expected)."""
-    X = torch.randn(50, 4)
-    score = PCAScore(exp_var=0.90)
-    score.fit(X, X)
-    out_cpu = score.score(X)
-    # move internal tensors to cpu explicitly and score again
-    score.to(device="cpu")
-    out_cpu2 = score.score(X)
-    approx(out_cpu, out_cpu2)

--- a/tests/test_pyod.py
+++ b/tests/test_pyod.py
@@ -24,7 +24,7 @@ class _MockDetectorRange:
     """Detector that assigns increasing decision_scores_ during fit.
     Useful for q-trimming tests."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.decision_scores_ = None
 
     def fit(self, X: np.ndarray) -> None:
@@ -53,7 +53,9 @@ def test_fit_sets_trained_and_scores_without_cal() -> None:
     assert torch.allclose(score.scores, torch.zeros(3))
 
 
-def test_fit_with_calibration_sets_calibrated_and_scores_from_decision_function() -> None:
+def test_fit_with_calibration_sets_calibrated_and_scores_from_decision_function() -> (
+    None
+):
     """When calibration embeddings are present, final scores should come from
     detector.decision_function and the score should be marked calibrated."""
     refs = torch.tensor([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
@@ -125,16 +127,16 @@ def test_pca_predict_is_applied_before_detector_fit() -> None:
     score.cal_required = False
     score.ref_embeddings = refs.clone()
 
-    class _MockPCA:
+    class _MockPCA(torch.nn.Module):
         def predict(self, X: torch.Tensor) -> torch.Tensor:
             # simple, deterministic transform for the test
             return X * 2.0
 
     # override _fit_pca to attach our mock PCA instance
-    def _attach_pca():
+    def _attach_pca() -> None:
         score.pca = _MockPCA()
 
-    score._fit_pca = _attach_pca
+    score._fit_pca = _attach_pca  # type: ignore [method-assign]
 
     score._fit_impl(q=None)
 


### PR DESCRIPTION
This PR  implements the scores as torch.nn.modules and uses buffers in order to simplify device management. 