### PR TITLE
adds selectiveInferenceTask as a LightningModule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "allclose",
         "autocast",
         "cdist",
         "embs",
@@ -24,6 +25,7 @@
         "pydocstyle",
         "pyod",
         "pytest",
+        "rtol",
         "scikit",
         "sdist",
         "seapig",

--- a/README.md
+++ b/README.md
@@ -31,59 +31,68 @@ Key features include:
 - Embeddings can be saved to / loaded from disk with outdir and prefix
   when using the \*\_dl helpers.
 
-If you have a trained model that exposes an .embed(x) method and PyTorch
-DataLoaders for train/val/test, you can let seapig extract embeddings on
-the fly. The DataLoader may yield plain tensors or dicts containing an
-“images” key.
+If you have a trained model that inherits from `torchgeo` tasks or your
+own lightning module, you can wrap your task in the
+`SelectiveInferenceTask` wrapper and use any of the provided confidence
+scores for selective inference. Here’s a minimal example using toy data
+and a tiny task:
 
 ``` python
 import torch
-from torch.utils.data import TensorDataset, DataLoader
 from torch import nn
-from seapig import EuclideanScore
+from torch.utils.data import TensorDataset, DataLoader
+from pytorch_lightning import LightningModule
 
-class TinyModel(nn.Module):
-    """Minimal model exposing an `embed(x)` method returning (B, D) tensors."""
-    def __init__(self):
+from seapig.scores.knn import EuclideanScore
+from seapig.model import SelectiveInferenceTask
+
+
+# the task could by any task supplied by torchgeo or your own LightningModule
+class TinyTask(LightningModule):
+    """Minimal LightningModule task exposing `predict(x)`."""
+
+    def __init__(self, num_classes: int = 2) -> None:
         super().__init__()
         self.backbone = nn.Sequential(
-            nn.Flatten(),
-            nn.Linear(2, 8),
-            nn.ReLU(),
-            nn.Linear(8, 4),
+            nn.Linear(2, 8), nn.ReLU(), nn.Linear(8, num_classes)
         )
-    def embed(self, x):
-        if isinstance(x, dict):
-            x = x["image"]
-        return self.backbone(x)
+        self.test_metrics = None
 
-# create small datasets (N x 2 features)
+    def predict(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.backbone(x)
+        return torch.argmax(logits, dim=1)
+
+
+# toy "embedding" datasets (N x 2 features) with labels
 train = torch.tensor([[0.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
 val = torch.tensor([[0.1, 0.0], [0.9, 1.1]], dtype=torch.float32)
-test = torch.tensor([[0.2, 0.1], [10.0, 10.0]], dtype=torch.float32)
+test = torch.tensor([[0.0, 0.1], [10.0, 10.0]], dtype=torch.float32)
+train_y = torch.tensor([0, 1])
+val_y = torch.tensor([0, 1])
+test_y = torch.tensor([0, 1])
 
-# ensure DataLoader returns tensors (not lists) by providing a collate_fn
-collate = lambda b: torch.stack([x[0] if isinstance(x, (list, tuple)) else x for x in b], 0)
-train_loader = DataLoader(TensorDataset(train), batch_size=2, collate_fn=collate)
-val_loader = DataLoader(TensorDataset(val), batch_size=2, collate_fn=collate)
-test_loader = DataLoader(TensorDataset(test), batch_size=1, collate_fn=collate)
+# fit confidence score on embeddings and calibrate a threshold
+score = EuclideanScore(k=1, stat="max")
+score.fit(X=train, Y=val)
+score.set_threshold(q=0.50)
 
-model = TinyModel()
-score = EuclideanScore(k=1, stat="max", exp_var=False)
-score.fit_dl(model=model, loaders={"train": train_loader, "val": val_loader}, outdir=None, prefix=None)
-score.set_threshold(q=0.75)
+# wrap the task with the score; default keys match torchgeo-style batches
+task = TinyTask(num_classes=2)
+wrapper = SelectiveInferenceTask(
+    task=task, score=score, input_key="image", target_key="label"
+)
 
-out = score.select_dl(model=model, loader=test_loader)
+# construct an inference/test batch
+batch = {"image": test, "label": test_y}
+
+# attach selection to predictions, and update/log the metric in test_step
+out = wrapper.predict_step(batch, batch_idx=0)
 out
 ```
 
-    Embedding 1 batches:   0%|          | 0/1 [00:00<?, ?batches/s]Embedding 1 batches: 100%|██████████| 1/1 [00:00<00:00, 1450.81batches/s]
-
-    Confidence score does not require calibration.
-
-    Embedding 2 batches:   0%|          | 0/2 [00:00<?, ?batches/s]Embedding 2 batches: 100%|██████████| 2/2 [00:00<00:00, 6359.82batches/s]
-
-    {'score': tensor([0.0277, 2.8308]), 'selected': tensor([ True, False])}
+    {'predictions': tensor([0, 0]),
+     'score': tensor([ 0.1000, 12.7279]),
+     'selected': tensor([ True, False])}
 
 Available scores
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ import torch
 from torch import nn
 from torch.utils.data import TensorDataset, DataLoader
 from pytorch_lightning import LightningModule
+from torchmetrics import Accuracy, MetricCollection
 
 from seapig.scores.knn import EuclideanScore
 from seapig.model import SelectiveInferenceTask
+from seapig.metric import SelectiveMetric
 
 
-# the task could by any task supplied by torchgeo or your own LightningModule
+# Define a minimal LightningModule task
 class TinyTask(LightningModule):
     """Minimal LightningModule task exposing `predict(x)`."""
 
@@ -56,14 +58,16 @@ class TinyTask(LightningModule):
         self.backbone = nn.Sequential(
             nn.Linear(2, 8), nn.ReLU(), nn.Linear(8, num_classes)
         )
-        self.test_metrics = None
+        self.test_metrics = MetricCollection(
+            {"accuracy": Accuracy(task="binary")}
+        )
 
     def predict(self, x: torch.Tensor) -> torch.Tensor:
         logits = self.backbone(x)
         return torch.argmax(logits, dim=1)
 
 
-# toy "embedding" datasets (N x 2 features) with labels
+# Toy "embedding" datasets (N x 2 features) with labels
 train = torch.tensor([[0.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
 val = torch.tensor([[0.1, 0.0], [0.9, 1.1]], dtype=torch.float32)
 test = torch.tensor([[0.0, 0.1], [10.0, 10.0]], dtype=torch.float32)
@@ -71,28 +75,33 @@ train_y = torch.tensor([0, 1])
 val_y = torch.tensor([0, 1])
 test_y = torch.tensor([0, 1])
 
-# fit confidence score on embeddings and calibrate a threshold
+# Fit confidence score on embeddings and calibrate a threshold
 score = EuclideanScore(k=1, stat="max")
 score.fit(X=train, Y=val)
 score.set_threshold(q=0.50)
 
-# wrap the task with the score; default keys match torchgeo-style batches
+# Wrap the task with the score; default keys match torchgeo-style batches
 task = TinyTask(num_classes=2)
 wrapper = SelectiveInferenceTask(
     task=task, score=score, input_key="image", target_key="label"
 )
 
-# construct an inference/test batch
+# Construct an inference/test batch
 batch = {"image": test, "label": test_y}
 
-# attach selection to predictions, and update/log the metric in test_step
+# Attach selection to predictions, and update/log the metric in test_step
 out = wrapper.predict_step(batch, batch_idx=0)
-out
+
+# Evaluate selective performance using SelectiveMetric
+metrics = MetricCollection({"accuracy": Accuracy(task="binary")})
+selective_metric = SelectiveMetric(metrics)
+selective_metric.update(out, test_y)
+results = selective_metric.compute()
+
+print("Selective evaluation results:", results)
 ```
 
-    {'predictions': tensor([0, 0]),
-     'score': tensor([ 0.1000, 12.7279]),
-     'selected': tensor([ True, False])}
+    Selective evaluation results: {'full/accuracy': tensor(0.5000), 'selected/accuracy': tensor(1.)}
 
 Available scores
 

--- a/README.qmd
+++ b/README.qmd
@@ -33,49 +33,61 @@ Key features include:
   using the *_dl helpers.
 
 
-If you have a trained model that exposes an .embed(x) method and PyTorch
-DataLoaders for train/val/test, you can let seapig extract embeddings on the
-fly. The DataLoader may yield plain tensors or dicts containing an "images"
-key.
+If you have a trained model that inherits from ``torchgeo`` tasks or your own
+lightning module, you can wrap your task in the `SelectiveInferenceTask` wrapper
+and use any of the provided confidence scores for selective inference. Here's a
+minimal example using toy data and a tiny task:
 
 ```{python}
 import torch
-from torch.utils.data import TensorDataset, DataLoader
 from torch import nn
-from seapig import EuclideanScore
+from torch.utils.data import TensorDataset, DataLoader
+from pytorch_lightning import LightningModule
 
-class TinyModel(nn.Module):
-    """Minimal model exposing an `embed(x)` method returning (B, D) tensors."""
-    def __init__(self):
+from seapig.scores.knn import EuclideanScore
+from seapig.model import SelectiveInferenceTask
+
+
+# the task could by any task supplied by torchgeo or your own LightningModule
+class TinyTask(LightningModule):
+    """Minimal LightningModule task exposing `predict(x)`."""
+
+    def __init__(self, num_classes: int = 2) -> None:
         super().__init__()
         self.backbone = nn.Sequential(
-            nn.Flatten(),
-            nn.Linear(2, 8),
-            nn.ReLU(),
-            nn.Linear(8, 4),
+            nn.Linear(2, 8), nn.ReLU(), nn.Linear(8, num_classes)
         )
-    def embed(self, x):
-        if isinstance(x, dict):
-            x = x["image"]
-        return self.backbone(x)
+        self.test_metrics = None
 
-# create small datasets (N x 2 features)
+    def predict(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.backbone(x)
+        return torch.argmax(logits, dim=1)
+
+
+# toy "embedding" datasets (N x 2 features) with labels
 train = torch.tensor([[0.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
 val = torch.tensor([[0.1, 0.0], [0.9, 1.1]], dtype=torch.float32)
-test = torch.tensor([[0.2, 0.1], [10.0, 10.0]], dtype=torch.float32)
+test = torch.tensor([[0.0, 0.1], [10.0, 10.0]], dtype=torch.float32)
+train_y = torch.tensor([0, 1])
+val_y = torch.tensor([0, 1])
+test_y = torch.tensor([0, 1])
 
-# ensure DataLoader returns tensors (not lists) by providing a collate_fn
-collate = lambda b: torch.stack([x[0] if isinstance(x, (list, tuple)) else x for x in b], 0)
-train_loader = DataLoader(TensorDataset(train), batch_size=2, collate_fn=collate)
-val_loader = DataLoader(TensorDataset(val), batch_size=2, collate_fn=collate)
-test_loader = DataLoader(TensorDataset(test), batch_size=1, collate_fn=collate)
+# fit confidence score on embeddings and calibrate a threshold
+score = EuclideanScore(k=1, stat="max")
+score.fit(X=train, Y=val)
+score.set_threshold(q=0.50)
 
-model = TinyModel()
-score = EuclideanScore(k=1, stat="max", exp_var=False)
-score.fit_dl(model=model, loaders={"train": train_loader, "val": val_loader}, outdir=None, prefix=None)
-score.set_threshold(q=0.75)
+# wrap the task with the score; default keys match torchgeo-style batches
+task = TinyTask(num_classes=2)
+wrapper = SelectiveInferenceTask(
+    task=task, score=score, input_key="image", target_key="label"
+)
 
-out = score.select_dl(model=model, loader=test_loader)
+# construct an inference/test batch
+batch = {"image": test, "label": test_y}
+
+# attach selection to predictions, and update/log the metric in test_step
+out = wrapper.predict_step(batch, batch_idx=0)
 out
 ```
 

--- a/README.qmd
+++ b/README.qmd
@@ -43,12 +43,14 @@ import torch
 from torch import nn
 from torch.utils.data import TensorDataset, DataLoader
 from pytorch_lightning import LightningModule
+from torchmetrics import Accuracy, MetricCollection
 
 from seapig.scores.knn import EuclideanScore
 from seapig.model import SelectiveInferenceTask
+from seapig.metric import SelectiveMetric
 
 
-# the task could by any task supplied by torchgeo or your own LightningModule
+# Define a minimal LightningModule task
 class TinyTask(LightningModule):
     """Minimal LightningModule task exposing `predict(x)`."""
 
@@ -57,14 +59,16 @@ class TinyTask(LightningModule):
         self.backbone = nn.Sequential(
             nn.Linear(2, 8), nn.ReLU(), nn.Linear(8, num_classes)
         )
-        self.test_metrics = None
+        self.test_metrics = MetricCollection(
+            {"accuracy": Accuracy(task="binary")}
+        )
 
     def predict(self, x: torch.Tensor) -> torch.Tensor:
         logits = self.backbone(x)
         return torch.argmax(logits, dim=1)
 
 
-# toy "embedding" datasets (N x 2 features) with labels
+# Toy "embedding" datasets (N x 2 features) with labels
 train = torch.tensor([[0.0, 0.0], [1.0, 1.0]], dtype=torch.float32)
 val = torch.tensor([[0.1, 0.0], [0.9, 1.1]], dtype=torch.float32)
 test = torch.tensor([[0.0, 0.1], [10.0, 10.0]], dtype=torch.float32)
@@ -72,23 +76,30 @@ train_y = torch.tensor([0, 1])
 val_y = torch.tensor([0, 1])
 test_y = torch.tensor([0, 1])
 
-# fit confidence score on embeddings and calibrate a threshold
+# Fit confidence score on embeddings and calibrate a threshold
 score = EuclideanScore(k=1, stat="max")
 score.fit(X=train, Y=val)
 score.set_threshold(q=0.50)
 
-# wrap the task with the score; default keys match torchgeo-style batches
+# Wrap the task with the score; default keys match torchgeo-style batches
 task = TinyTask(num_classes=2)
 wrapper = SelectiveInferenceTask(
     task=task, score=score, input_key="image", target_key="label"
 )
 
-# construct an inference/test batch
+# Construct an inference/test batch
 batch = {"image": test, "label": test_y}
 
-# attach selection to predictions, and update/log the metric in test_step
+# Attach selection to predictions, and update/log the metric in test_step
 out = wrapper.predict_step(batch, batch_idx=0)
-out
+
+# Evaluate selective performance using SelectiveMetric
+metrics = MetricCollection({"accuracy": Accuracy(task="binary")})
+selective_metric = SelectiveMetric(metrics)
+selective_metric.update(out, test_y)
+results = selective_metric.compute()
+
+print("Selective evaluation results:", results)
 ```
 
 Available scores

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -8,3 +8,4 @@ tqdm
 pyarrow
 faiss-cpu
 pyod
+lightning

--- a/seapig/__init__.py
+++ b/seapig/__init__.py
@@ -10,14 +10,16 @@ to derive confidence scores to be applied for selective prediction systems.
 __author__ = "Darius A. Görgen"
 __version__ = "0.0.1"
 
-from seapig.model import SelectiveModel
+from seapig.metric import SelectiveMetric
+from seapig.model import SelectiveInferenceTask
 from seapig.scores.base import RandomScore
 from seapig.scores.knn import CosineScore, EuclideanScore, MahalanobisScore
 from seapig.scores.pca import PCAScore
 from seapig.scores.pyod import PyODScore
 
 __all__ = [
-    "SelectiveModel",
+    "SelectiveInferenceTask",
+    "SelectiveMetric",
     "RandomScore",
     "EuclideanScore",
     "CosineScore",

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -4,7 +4,7 @@ import torch
 from torchmetrics import Metric, MetricCollection
 
 
-class SelectiveMetric(Metric):
+class SelectiveMetric(Metric):  # type: ignore[misc]
     """Wrap a torchmetrics metric for selective evaluation.
 
     This wrapper keeps two independent instances of an underlying

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -1,0 +1,116 @@
+"""Selective evaluation metric wrapper."""
+
+import torch
+from torchmetrics import Metric, MetricCollection
+
+
+class SelectiveMetric(Metric):
+    """Wrap a torchmetrics metric for selective evaluation.
+
+    This wrapper keeps two independent instances of an underlying
+    ``Metric`` or ``MetricCollection`` and updates them with (1) all
+    samples and (2) only the selected samples indicated by a boolean
+    mask inside the provided output dictionary.
+
+    The ``update`` method accepts a mapping like the output of
+    :meth:`SelectiveInferenceTask.forward`, containing:
+
+    - model predictions under ``prediction_key`` (shape ``(B, ...)``, default: ``"predictions"``)
+    - a selection mask under ``selection_key`` (default: ``"selected"``)
+
+    And the target tensor of shape ``(B, ...)``.
+
+    Parameters
+    ----------
+    base : Metric | MetricCollection
+        The metric (or collection) to evaluate. Two deep-copied instances
+        are maintained internally for full and selective risk computation.
+    prediction_key : str, optional
+        Key for predictions inside the outputs dict, by default "predictions".
+    selection_key : str, optional
+        Key for the selection mask inside the outputs dict, by default
+        "selected".
+
+    Notes
+    -----
+    - If the selection mask is a float/integer tensor, values ``> 0``
+      are treated as selected.
+    - If no samples are selected, the selected metric is not updated for
+        that call.
+    """
+
+    def __init__(
+        self,
+        base: Metric | MetricCollection,
+        prediction_key: str = "predictions",
+        selection_key: str = "selected",
+    ) -> None:
+        super().__init__()
+        import copy as _copy
+
+        # Two independent metric instances (full vs selection)
+        self._full: Metric | MetricCollection = _copy.deepcopy(base)
+        self._selected: Metric | MetricCollection = _copy.deepcopy(base)
+
+        self.prediction_key = prediction_key
+        self.selection_key = selection_key
+
+    def update(
+        self, outputs: dict[str, torch.Tensor], target: torch.Tensor
+    ) -> None:
+        """Update both full and selected metrics.
+
+        Parameters
+        ----------
+        outputs : dict[str, torch.Tensor]
+            Mapping containing predictions, a target tensor, and selection
+            mask.
+        """
+        preds = outputs[self.prediction_key]
+        mask = outputs[self.selection_key]
+
+        device = preds.device
+        # Ensure both metrics are on the right device
+        self._full = self._full.to(device)
+        self._selected = self._selected.to(device)
+
+        # Update total
+        self._full.update(preds, target)
+
+        # Update selected subset (if any)
+        if mask.ndim != 1:
+            mask = mask.view(-1)
+        if mask.any():
+            if mask.dtype is not torch.bool:
+                mask = mask == 1
+            preds_sel = preds[mask]
+            target_sel = target[mask]
+            self._selected.update(preds_sel, target_sel)
+
+    def compute(self) -> dict[str, torch.Tensor]:
+        """Compute and return results for total and selected.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            Prefixed results. For a single metric, keys are
+            ``"full_risk"`` and ``"selective_risk"``. For a collection,
+            keys are prefixed as ``"full/<name>"`` and ``"selected/<name>"``.
+        """
+
+        def _to_mapping(
+            m: Metric | MetricCollection, prefix: str
+        ) -> dict[str, torch.Tensor]:
+            out = m.compute()
+            if isinstance(out, dict):
+                return {f"{prefix}/{k}": v for k, v in out.items()}
+            return {"full_risk" if prefix == "full" else "selective_risk": out}
+
+        total_map = _to_mapping(self._full, "full")
+        selected_map = _to_mapping(self._selected, "selected")
+        return {**total_map, **selected_map}
+
+    def reset(self) -> None:
+        """Reset both internal metric instances."""
+        self._full.reset()
+        self._selected.reset()

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -1,33 +1,162 @@
-"""Selective Model Class."""
+"""Selective inference task wrapper.
+
+Wraps a ``pytorch_lightning.LightningModule`` and a ``seapig`` confidence
+score so that the model’s output is automatically combined with the score’s
+selection results.
+"""
+
+from typing import Any, Literal, get_args
 
 import torch
+from pytorch_lightning import LightningModule
+from torchmetrics import MetricCollection
 
 from seapig.scores.base import ConfidenceScore
 
+INPUT_KEYS = Literal["image", "input", "images", "inputs", "x"]
+TARGET_KEYS = Literal[
+    "mask", "label", "masks", "labels", "targets", "target", "y", "y_true"
+]
 
-class SelectiveModel(torch.nn.Module):  # type: ignore[misc]
-    """Wrap a model to apply selection during inference."""
 
-    model: torch.nn.Module
-    csf: ConfidenceScore
+class SelectiveInferenceTask(LightningModule):  # type: ignore[misc]
+    """Wrap a LightningModule to attach a confidence‑score based selector.
+
+    This task is designed to be compatible with ``torchgeo`` based tasks and
+    models. It is meant to be used in inference mode only, so you are required
+    to bring a trained model. This wrapper supplies extended  methods for
+    the `test_step()` and `predict_step()` of the LightningModule that
+    automatically attach selection results from the provided confidence score.
+    Combined with the seapig `selectiveMetric`s, this allows for easy
+    evaluation of selective performance during testing and prediction with a
+    pytorch-lightning `Trainer`.
+
+    Parameters
+    ----------
+    task : LightningModule
+        The model (or any LightningModule) whose ``forward`` method produces
+        predictions.  The returned value may be a tensor or a mapping of
+        tensors.
+    score : ConfidenceScore
+        A ``seapig`` confidence‑score object providing a ``select`` method.
+    input_key : input_keys, optional
+        The key in the input batch dictionary corresponding to the model
+        inputs, by default "image".
+    target_key : target_keys, optional
+        The key in the input batch dictionary corresponding to the model
+        targets, by default "label".
+    """
 
     def __init__(
-        self, model: torch.nn.Module, confidence_score: ConfidenceScore
+        self,
+        task: LightningModule,
+        score: ConfidenceScore,
+        input_key: INPUT_KEYS = "image",
+        target_key: TARGET_KEYS = "label",
     ) -> None:
         super().__init__()
-        self.model = model
-        self.csf = confidence_score
+        self.task = task
+        self.score = score
+        if input_key not in get_args(INPUT_KEYS):
+            raise ValueError(
+                f"input_key must be one of {get_args(INPUT_KEYS)}; got {input_key!r}"
+            )
+        self.input_key = input_key
+        if target_key not in get_args(TARGET_KEYS):
+            raise ValueError(
+                f"target_key must be one of {get_args(TARGET_KEYS)}; got {target_key!r}"
+            )
+        self.target_key = target_key
+        # TODO: wrap metrics to be selective metrics here
+        assert hasattr(task, "test_metrics"), (
+            "Wrapped task must have test_metrics"
+        )
+        self.test_metrics = task.test_metrics
 
     @torch.inference_mode()  # type: ignore[untyped-decorator]
     def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
-        """Implement forward pass with confidence score selection."""
-        preds: torch.Tensor | dict[str, torch.Tensor] = self.model(x)
+        """Run the wrapped model and attach selection scores.
+
+        The wrapped ``task`` is called first.  Its output is normalised to a
+        ``dict`` under the key ``"predictions"`` when a plain tensor is
+        returned.  The confidence‑score ``select`` method is then evaluated on
+        the same input batch, moved to the device of the model’s predictions,
+        and merged with the prediction mapping.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary containing the original predictions together with the
+            selection scores.
+        """
+        preds: dict[str, torch.Tensor] | torch.Tensor = self.task.predict(x)
         if isinstance(preds, torch.Tensor):
             preds = {"predictions": preds}
         assert isinstance(preds, dict)
-        scores: dict[str, torch.Tensor] = self.csf.select(x)
-        scores = {
-            k: v.to(device=str(preds["predictions"].device))
-            for k, v in scores.items()
-        }
-        return preds | scores
+
+        self.score.to(device=str(x.device))
+        selection = self.score.select(x)
+
+        return preds | selection
+
+    @torch.inference_mode()  # type: ignore[untyped-decorator]
+    def test_step(
+        self, batch: dict[str, Any], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Perform a test step with selection results attached.
+
+        This method calls the wrapped task’s ``test_step`` method, but
+        replaces the output predictions with those from this wrapper’s
+        ``forward`` method.  This ensures that selection results are included
+        in the output.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            A batch of data.
+        batch_idx : int
+            The index of the batch.
+
+        Returns
+        -------
+        dict[str, Any]
+            The output of the wrapped task’s ``test_step``, but with
+            predictions replaced by those from this wrapper.
+        """
+        x = batch[self.input_key]
+        y = batch[self.target_key]
+        batch_size = x.shape[0]
+        outputs = self.forward(x)
+        assert isinstance(self.test_metrics, MetricCollection)
+        self.test_metrics(outputs["predictions"], y)
+        self.log_dict(self.test_metrics, batch_size=batch_size)
+
+    @torch.inference_mode()  # type: ignore[untyped-decorator]
+    def predict_step(
+        self, batch: dict[str, Any], batch_idx: int, dataloader_idx: int = 0
+    ) -> dict[str, torch.Tensor]:
+        """Perform a predict step with selection results attached.
+
+        This method calls the wrapped task’s ``predict_step`` method, but
+        replaces the output predictions with those from this wrapper’s
+        ``forward`` method.  This ensures that selection results are included
+        in the output.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            A batch of data.
+        batch_idx : int
+            The index of the batch.
+        dataloader_idx : int, optional
+            The index of the dataloader, by default 0.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            The output of the wrapped task’s ``predict_step``, but with
+            predictions replaced by those from this wrapper.
+        """
+        x = batch[self.input_key]
+        outputs: dict[str, torch.Tensor] = self.forward(x)
+        return outputs

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -147,3 +147,30 @@ def test_selective_metric_with_metric_collection_output_naming() -> None:
     # Check that all values are scalars
     for value in res.values():
         assert isinstance(value, torch.Tensor) and value.ndim == 0
+
+
+def test_selective_metric_reset() -> None:
+    base = Accuracy(task="binary")
+    sel = SelectiveMetric(base)
+
+    # Update the metric with some data
+    outputs = {
+        "predictions": torch.tensor([0.9, 0.4, 0.6, 0.8]),
+        "selected": torch.tensor([1, 0, 1, 0]),
+    }
+    target = torch.tensor([1, 0, 1, 0])
+    sel.update(outputs, target)
+
+    # Ensure the metric has non-zero state
+    res_before_reset = sel.compute()
+    assert sel._full.fp == torch.tensor(1)
+    assert sel._selected.tp == torch.tensor(2)
+
+    # Reset the metric
+    sel.reset()
+
+    # Compute after reset and ensure the state is cleared
+    res_after_reset = sel.compute()
+    assert sel._full.fp == torch.tensor(0)
+    assert sel._selected.tp == torch.tensor(0)
+    assert res_before_reset == res_after_reset  # returns last cached result

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,0 +1,149 @@
+import torch
+from pytorch_lightning import LightningModule
+from torchmetrics import Accuracy, MetricCollection, Precision, Recall
+
+from seapig import SelectiveInferenceTask, SelectiveMetric
+
+
+class DummyScore:
+    """Minimal duck-typed score with select() and to()."""
+
+    def __init__(self) -> None:
+        self.last_device: str | None = None
+
+    def to(self, device: str) -> "DummyScore":
+        self.last_device = device
+        return self
+
+    def select(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        b = x.shape[0]
+        return {
+            "score": torch.arange(b, dtype=x.dtype, device=x.device),
+            "selected": torch.ones(b, dtype=torch.bool, device=x.device),
+        }
+
+
+class DummyTaskTensor(LightningModule):
+    """Task that returns a tensor from predict()."""
+
+    test_metrics: MetricCollection = MetricCollection(Accuracy(task="binary"))
+
+    def predict(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return 2 * x
+
+
+class DummyTaskDict(LightningModule):
+    """Task that returns a mapping from predict()."""
+
+    test_metrics: MetricCollection = MetricCollection(Accuracy(task="binary"))
+
+    def predict(self, x: torch.Tensor) -> dict[str, torch.Tensor]:  # type: ignore[override]
+        return {"predictions": 3 * x, "extra": x.sum(dim=1)}
+
+
+def test_selective_metric_binary_accuracy_full_vs_selected() -> None:
+    base = Accuracy(task="binary")
+    sel = SelectiveMetric(base)
+
+    # Predictions as probabilities; targets are 0/1
+    outputs = {
+        "predictions": torch.tensor([0.9, 0.4, 0.6, 0.8]),
+        "selected": torch.tensor([1, 1, 0, 0]),  # non-bool mask accepted
+    }
+    target = torch.tensor([1, 0, 1, 0])
+
+    sel.update(outputs, target)
+    res = sel.compute()
+
+    # Expect full accuracy: correct on 0.9, 0.4, 0.6; wrong on 0.8 => 3/4 = 0.75
+    assert "full_risk" in res and torch.allclose(
+        res["full_risk"], torch.tensor(0.75)
+    )
+    # Selected accuracy considers first two only, both correct => 1.0
+    assert "selective_risk" in res and torch.allclose(
+        res["selective_risk"], torch.tensor(1.0)
+    )
+
+
+def test_selective_metric_with_metric_collection_prefix_keys() -> None:
+    coll = MetricCollection({"acc": Accuracy(task="binary")})
+    sel = SelectiveMetric(coll)
+
+    outputs = {
+        "predictions": torch.tensor([0.9, 0.4, 0.6, 0.8]),
+        "selected": torch.tensor([1, 0, 1, 0]),
+    }
+    target = torch.tensor([1, 0, 1, 0])
+
+    sel.update(outputs, target)
+    res = sel.compute()
+
+    # Keys should be prefixed for collections
+    assert any(k.startswith("full/") for k in res.keys())
+    assert any(k.startswith("selected/") for k in res.keys())
+    # Values are scalars
+    for v in res.values():
+        assert isinstance(v, torch.Tensor) and v.ndim == 0
+
+
+def test_selective_metric_end_to_end_with_task_outputs() -> None:
+    # Use SelectiveInferenceTask to produce outputs dict, then evaluate SelectiveMetric
+    task = DummyTaskTensor()
+    score = DummyScore()
+    w = SelectiveInferenceTask(task=task, score=score)
+
+    x = torch.tensor([0.2, 0.7, 0.6, 0.1])
+    outputs = w.forward(x)
+    # Override selection to choose two samples
+    outputs["selected"] = torch.tensor([True, True, False, False])
+    outputs["predictions"] = torch.tensor([0.0, 1.0, 0.0, 1.0])
+
+    # Binary targets compatible with predictions thresholding at 0.5
+    target = torch.tensor([0, 1, 1, 0])
+
+    sel = SelectiveMetric(Accuracy(task="binary"))
+    sel.update(outputs, target)
+    res = sel.compute()
+
+    # Full accuracy across all 4 predictions: half correct => 0.5
+    assert torch.allclose(res["full_risk"], torch.tensor(0.5))
+    # Selected accuracy on first two samples: both correct => 1.0
+    assert torch.allclose(res["selective_risk"], torch.tensor(1.0))
+
+
+def test_selective_metric_with_metric_collection_output_naming() -> None:
+    # Define a MetricCollection with multiple metrics
+    metrics = MetricCollection(
+        {
+            "accuracy": Accuracy(task="binary"),
+            "precision": Precision(task="binary"),
+            "recall": Recall(task="binary"),
+        }
+    )
+    sel = SelectiveMetric(metrics)
+
+    # Define outputs and targets
+    outputs = {
+        "predictions": torch.tensor([0.9, 0.4, 0.6, 0.8]),
+        "selected": torch.tensor([1, 0, 1, 0]),  # non-bool mask accepted
+    }
+    target = torch.tensor([1, 0, 1, 0])
+
+    # Update and compute the metrics
+    sel.update(outputs, target)
+    res = sel.compute()
+
+    # Check that all keys are correctly prefixed
+    expected_keys = {
+        "full/accuracy",
+        "selected/accuracy",
+        "full/precision",
+        "selected/precision",
+        "full/recall",
+        "selected/recall",
+    }
+    assert set(res.keys()) == expected_keys
+
+    # Check that all values are scalars
+    for value in res.values():
+        assert isinstance(value, torch.Tensor) and value.ndim == 0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,191 @@
+import pytest
+import torch
+from pytorch_lightning import LightningModule
+from torchmetrics import Accuracy, MetricCollection
+
+from seapig import SelectiveInferenceTask
+
+
+class DummyScore:
+    """Minimal duck-typed score with select() and to()."""
+
+    def __init__(self) -> None:
+        self.last_device: str | None = None
+
+    def to(self, device: str) -> "DummyScore":
+        self.last_device = device
+        return self
+
+    def select(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
+        b = x.shape[0]
+        return {
+            "score": torch.arange(b, dtype=x.dtype, device=x.device),
+            "selected": torch.ones(b, dtype=torch.bool, device=x.device),
+        }
+
+
+class DummyTaskTensor(LightningModule):
+    """Task that returns a tensor from predict()."""
+
+    test_metrics: MetricCollection = MetricCollection(Accuracy(task="binary"))
+
+    def predict(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return 2 * x
+
+
+class DummyTaskDict(LightningModule):
+    """Task that returns a mapping from predict()."""
+
+    test_metrics: MetricCollection = MetricCollection(Accuracy(task="binary"))
+
+    def predict(self, x: torch.Tensor) -> dict[str, torch.Tensor]:  # type: ignore[override]
+        return {"predictions": 3 * x, "extra": x.sum(dim=1)}
+
+
+def test_init_accepts_default_and_alt_keys() -> None:
+    s = DummyScore()
+    w = SelectiveInferenceTask(task=DummyTaskTensor(), score=s)
+    assert w.input_key == "image" and w.target_key == "label"
+
+    w2 = SelectiveInferenceTask(
+        task=DummyTaskTensor(), score=s, input_key="x", target_key="y_true"
+    )
+    assert w2.input_key == "x" and w2.target_key == "y_true"
+
+
+@pytest.mark.parametrize(
+    "kw, key, value",
+    [
+        ("input_key", "bad_input", "not-a-key"),
+        ("target_key", "bad_target", "also-bad"),
+    ],
+)
+def test_init_rejects_invalid_keys(kw: str, key: str, value: str) -> None:
+    kwargs: dict[str, object] = {kw: value}
+    with pytest.raises(ValueError):
+        SelectiveInferenceTask(
+            task=DummyTaskTensor(), score=DummyScore(), **kwargs
+        )
+
+
+def test_forward_wraps_tensor_and_merges_selection() -> None:
+    task = DummyTaskTensor()
+    score = DummyScore()
+    w = SelectiveInferenceTask(task=task, score=score)
+
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    out = w.forward(x)
+
+    # predictions wrapped and equal to 2*x
+    assert "predictions" in out and torch.allclose(out["predictions"], 2 * x)
+    # selection merged
+    assert set(["score", "selected"]).issubset(out.keys())
+    # device propagated to score.to(...)
+    assert score.last_device == str(x.device)
+
+
+def test_forward_keeps_dict_output_and_extra_keys() -> None:
+    task = DummyTaskDict()
+    score = DummyScore()
+    w = SelectiveInferenceTask(task=task, score=score)
+
+    x = torch.tensor([[1.0, 2.0]])
+    out = w.forward(x)
+
+    assert torch.allclose(out["predictions"], 3 * x)
+    # ensure original extra entries survive merge
+    assert "extra" in out and out["extra"].shape[0] == x.shape[0]
+    assert "score" in out and "selected" in out
+
+
+def test_forward_raises_when_predict_not_tensor_or_dict() -> None:
+    class BadTask(LightningModule):
+        test_metrics: MetricCollection = MetricCollection(
+            Accuracy(task="binary")
+        )
+
+        def predict(self, x: torch.Tensor):  # type: ignore[override]
+            return [x]  # wrong type
+
+    w = SelectiveInferenceTask(task=BadTask(), score=DummyScore())
+    with pytest.raises(AssertionError):
+        _ = w.forward(torch.randn(2, 3))
+
+
+def test_predict_step_uses_input_key_and_returns_selection() -> None:
+    task = DummyTaskTensor()
+    score = DummyScore()
+    w = SelectiveInferenceTask(task=task, score=score)
+
+    batch = {"image": torch.tensor([[1.0, 2.0], [3.0, 4.0]])}
+    out = w.predict_step(batch, batch_idx=0)
+    assert "predictions" in out and torch.allclose(
+        out["predictions"], 2 * batch["image"]
+    )  # type: ignore[index]
+    assert out["selected"].dtype is torch.bool
+
+
+def test_predict_step_missing_key_raises_keyerror() -> None:
+    w = SelectiveInferenceTask(task=DummyTaskTensor(), score=DummyScore())
+    with pytest.raises(KeyError):
+        _ = w.predict_step({"not_image": torch.zeros(1, 2)}, batch_idx=0)
+
+
+def test_test_step_calls_metrics_and_logs(monkeypatch) -> None:
+    task = DummyTaskTensor()
+    score = DummyScore()
+    w = SelectiveInferenceTask(task=task, score=score)
+
+    calls: dict[str, object] = {"metrics_calls": 0, "log_arg": None}
+
+    class DummyMetrics(MetricCollection):
+        def __call__(self, outputs, y):  # noqa: ANN001
+            calls["metrics_calls"] = int(calls["metrics_calls"]) + 1
+
+    # attach a callable metrics object and stub log_dict to accept any input
+    w.test_metrics = DummyMetrics(Accuracy(task="binary"))  # type: ignore[attr-defined]
+
+    def fake_log_dict(arg, batch_size=None):  # noqa: ANN001
+        calls["log_arg"] = arg
+        return None
+
+    monkeypatch.setattr(w, "log_dict", fake_log_dict)
+
+    batch = {
+        "image": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        "label": torch.tensor([0, 1]),
+    }
+    w.test_step(batch, batch_idx=0)
+
+    # metrics called once, and our stub log_dict received the metrics object
+    assert calls["metrics_calls"] == 1
+    assert calls["log_arg"] is w.test_metrics
+
+
+def test_test_step_with_alt_keys(monkeypatch) -> None:
+    task = DummyTaskTensor()
+    score = DummyScore()
+    w = SelectiveInferenceTask(
+        task=task, score=score, input_key="x", target_key="y"
+    )
+
+    class DummyMetrics(MetricCollection):
+        def __call__(self, outputs, y):  # noqa: ANN001
+            # ensure y is the provided target
+            assert torch.equal(y, torch.tensor([1, 1]))
+
+    w.test_metrics = DummyMetrics(Accuracy(task="binary"))  # type: ignore[attr-defined]
+    monkeypatch.setattr(w, "log_dict", lambda *a, **k: None)
+
+    batch = {"x": torch.tensor([[1.0, 2.0]]), "y": torch.tensor([1, 1])}
+    w.test_step(batch, batch_idx=0)
+
+
+def test_test_step_missing_keys_raise_keyerror(monkeypatch) -> None:
+    w = SelectiveInferenceTask(task=DummyTaskTensor(), score=DummyScore())
+    monkeypatch.setattr(w, "log_dict", lambda *a, **k: None)
+
+    with pytest.raises(KeyError):
+        w.test_step({"label": torch.tensor([0])}, batch_idx=0)
+    with pytest.raises(KeyError):
+        w.test_step({"image": torch.zeros(1, 2)}, batch_idx=0)


### PR DESCRIPTION
This PR refactors `model.py` to wrap a `pytorch_lightning.LightningModule` and extend its forward pass with the selection functionality of a score. This implementation is currently WIP. In the future, it should include sensible extensions of the respective defaults in torchgeo for `eval_step()` and `predict_step()`. Most likely, this will not include training and validation, since selection of inputs currently is only implemented as a post-hoc method during inference. 