### PR TITLE
register SelectiveMetric submetrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ exclude = ["tests*", "docs", "_extensions"]
 [tool.pytest.ini_options]
 filterwarnings = [
   "ignore: builtin type .* has no __module__ attribute:DeprecationWarning",
-  "ignore: The 'predict_dataloader' does not have many workers.*:UserWarning",
+  "ignore: The '.*_dataloader' does not have many workers.*:UserWarning",
   "ignore: Query \\d+ returned fewer than \\d+ neighbors\\.",
 ]
 testpaths = ["tests", "."]

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -53,10 +53,20 @@ class SelectiveMetric(Metric):  # type: ignore[misc]
         super().__init__()
         import copy as _copy
 
-        # Three independent metric instances (full, selection, rejection)
-        self._full: Metric | MetricCollection = _copy.deepcopy(base)
-        self._selected: Metric | MetricCollection = _copy.deepcopy(base)
-        self._rejected: Metric | MetricCollection = _copy.deepcopy(base)
+        # Deep-copy the base metric/collection for independent state
+        full = _copy.deepcopy(base)
+        selected = _copy.deepcopy(base)
+        rejected = _copy.deepcopy(base)
+
+        # Register as submodules so torch/Lightning see and manage them
+        self._full = full
+        self.add_module("_full", self._full)
+
+        self._selected = selected
+        self.add_module("_selected", self._selected)
+
+        self._rejected = rejected
+        self.add_module("_rejected", self._rejected)
 
         self.prediction_key = prediction_key
         self.selection_key = selection_key
@@ -85,19 +95,21 @@ class SelectiveMetric(Metric):  # type: ignore[misc]
             mask.
         """
         predictions = outputs[self.prediction_key]
-        selected = outputs[self.selection_key]
+        selected = outputs[self.selection_key].bool()
+        rejected = ~selected
 
         device = predictions.device
-        self._full = self._full.to(device)
-        self._selected = self._selected.to(device)
-        self._rejected = self._rejected.to(device)
+        self._full.to(device)
+        self._selected.to(device)
+        self._rejected.to(device)
 
+        # Update full with all samples
         self._full.update(predictions, target)
 
+        # Conditionally update selected/rejected submetrics
         if selected.any():
             self._selected.update(predictions[selected], target[selected])
 
-        rejected = ~selected
         if rejected.any():
             self._rejected.update(predictions[rejected], target[rejected])
 

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -292,9 +292,9 @@ class RiskCoverageMetric(Metric):  # type: ignore[misc]
         self._last_curve = rc
         device = self.scores.device
         return {
-            "rc/auc_empirical": torch.tensor(rc.auc_empirical, device=device),
-            "rc/auc_reference": torch.tensor(rc.auc_reference, device=device),
-            "rc/auc_excess": torch.tensor(rc.auc_excess, device=device),
+            "rc/auc_empirical": torch.as_tensor(rc.auc_empirical, device=device),
+            "rc/auc_reference": torch.as_tensor(rc.auc_reference, device=device),
+            "rc/auc_excess": torch.as_tensor(rc.auc_excess, device=device),
         }
 
     def get_curve(self) -> RiskCoverage | None:

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -203,11 +203,13 @@ class RiskCoverageMetric(Metric):  # type: ignore[misc]
         self._error_fn = error_fn
 
         # Metric states (concatenate across steps)
+        self.scores = torch.tensor([], dtype=torch.float32)
         self.add_state(
             "scores",
             default=torch.tensor([], dtype=torch.float32),
             dist_reduce_fx="cat",
         )
+        self.residuals = torch.tensor([], dtype=torch.float32)
         self.add_state(
             "residuals",
             default=torch.tensor([], dtype=torch.float32),
@@ -292,8 +294,12 @@ class RiskCoverageMetric(Metric):  # type: ignore[misc]
         self._last_curve = rc
         device = self.scores.device
         return {
-            "rc/auc_empirical": torch.as_tensor(rc.auc_empirical, device=device),
-            "rc/auc_reference": torch.as_tensor(rc.auc_reference, device=device),
+            "rc/auc_empirical": torch.as_tensor(
+                rc.auc_empirical, device=device
+            ),
+            "rc/auc_reference": torch.as_tensor(
+                rc.auc_reference, device=device
+            ),
             "rc/auc_excess": torch.as_tensor(rc.auc_excess, device=device),
         }
 

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -261,26 +261,26 @@ class RiskCoverageMetric(Metric):  # type: ignore[misc]
         err_fn = self._error_fn or self._default_error_fn
         residuals = err_fn(preds, target).to(device)
 
-        # Concatenate into states
+        # Concatenate into states (keep dtype/device consistent)
         if self.scores.numel() == 0:
-            self.scores: torch.Tensor = scores
+            self.scores = scores
         else:
             self.scores = torch.cat([self.scores, scores], dim=0)
 
         if self.residuals.numel() == 0:
-            self.residuals: torch.Tensor = residuals
+            self.residuals = residuals
         else:
             self.residuals = torch.cat([self.residuals, residuals], dim=0)
 
     def compute(self) -> dict[str, torch.Tensor]:
         """Compute risk-coverage curve metrics."""
         if self.scores.numel() == 0:
-            # No data yet; return zeros
+            # No data yet; return zeros on the registered device
             zero = torch.tensor(0.0, device=self.scores.device)
             return {
                 "rc/auc_empirical": zero,
                 "rc/auc_reference": zero,
-                "rc/e_aurc": zero,
+                "rc/auc_excess": zero,
             }
 
         rc = risk_coverage(
@@ -290,10 +290,11 @@ class RiskCoverageMetric(Metric):  # type: ignore[misc]
             n_bins=self.n_bins,
         )
         self._last_curve = rc
+        device = self.scores.device
         return {
-            "rc/auc_empirical": rc.auc_empirical,
-            "rc/auc_reference": rc.auc_reference,
-            "rc/auc_excess": rc.auc_excess,
+            "rc/auc_empirical": torch.tensor(rc.auc_empirical, device=device),
+            "rc/auc_reference": torch.tensor(rc.auc_reference, device=device),
+            "rc/auc_excess": torch.tensor(rc.auc_excess, device=device),
         }
 
     def get_curve(self) -> RiskCoverage | None:

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -147,14 +147,17 @@ class SelectiveInferenceTask(LightningModule):  # type: ignore[misc]
         """
         x = batch[self.input_key]
         y = batch[self.target_key]
+        batch_size = x.shape[0]
 
         outputs = self.forward(x)
 
         self.test_metrics.update(outputs, y)
+        self.log_dict(self.test_metrics, batch_size=batch_size)
 
         # Update risk‑coverage metric; final values are logged in on_test_epoch_end
         if self.rc_metric is not None:
             self.rc_metric.update(outputs, y)
+            self.log_dict(self.rc_metric, batch_size=batch_size)
 
     def on_test_epoch_end(self) -> None:
         """Log final computed test metrics once (avoid per-batch aggregation)."""

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -163,7 +163,7 @@ class SelectiveInferenceTask(LightningModule):  # type: ignore[misc]
         """Log final computed test metrics once (avoid per-batch aggregation)."""
         if hasattr(self, "test_metrics"):
             self.log_dict(self.test_metrics.compute(), sync_dist=True)
-        if getattr(self, "rc_metric", None) is not None:
+        if self.rc_metric is not None:
             self.log_dict(self.rc_metric.compute(), sync_dist=True)
 
     @torch.inference_mode()  # type: ignore[untyped-decorator]

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -147,18 +147,21 @@ class SelectiveInferenceTask(LightningModule):  # type: ignore[misc]
         """
         x = batch[self.input_key]
         y = batch[self.target_key]
-        batch_size = x.shape[0]
 
         outputs = self.forward(x)
 
-        # Update metrics:
-        self.test_metrics(outputs, y)
-        self.log_dict(self.test_metrics, batch_size=batch_size)
+        self.test_metrics.update(outputs, y)
 
-        # Update risk‑coverage metric and log AUCs
+        # Update risk‑coverage metric; final values are logged in on_test_epoch_end
         if self.rc_metric is not None:
-            self.rc_metric(outputs, y)
-            self.log_dict(self.rc_metric, batch_size=batch_size)
+            self.rc_metric.update(outputs, y)
+
+    def on_test_epoch_end(self) -> None:
+        """Log final computed test metrics once (avoid per-batch aggregation)."""
+        if hasattr(self, "test_metrics"):
+            self.log_dict(self.test_metrics.compute(), sync_dist=True)
+        if getattr(self, "rc_metric", None) is not None:
+            self.log_dict(self.rc_metric.compute(), sync_dist=True)
 
     @torch.inference_mode()  # type: ignore[untyped-decorator]
     def predict_step(

--- a/tests/test_selective_integration.py
+++ b/tests/test_selective_integration.py
@@ -1,4 +1,4 @@
-# python
+import pytest
 import torch
 from lightning import LightningDataModule, LightningModule, Trainer
 from torch.utils.data import DataLoader, Dataset
@@ -99,7 +99,9 @@ def _tensor_dict_to_floats(d: dict) -> dict:
             out[k] = v
     return out
 
-
+@pytest.mark.filterwarnings(
+    r"ignore:`isinstance\(treespec, LeafSpec\)` is deprecated.*"
+)
 def test_selective_inference_trainer_integration(tmp_path):
     task = DummyTask()
     score = FlagScore()
@@ -162,7 +164,9 @@ def test_selective_inference_trainer_integration(tmp_path):
     )
     assert metric_floats["rejected/BinaryAccuracy"] > 0.0
 
-
+@pytest.mark.filterwarnings(
+    r"ignore:`isinstance\(treespec, LeafSpec\)` is deprecated.*"
+)
 def test_risk_coverage_integration_via_trainer(tmp_path):
     task = DummyTask()
     score = FlagScore()

--- a/tests/test_selective_integration.py
+++ b/tests/test_selective_integration.py
@@ -1,0 +1,158 @@
+# python
+import torch
+from lightning import LightningDataModule, LightningModule, Trainer
+from torch.utils.data import DataLoader, Dataset
+from torchmetrics import Accuracy
+
+from seapig.model import SelectiveInferenceTask
+from seapig.scores.base import ConfidenceScore
+
+
+class DummyTask(LightningModule):
+    """Forward returns predictions; embed returns the input so selection can be driven by input."""
+
+    def __init__(self):
+        super().__init__()
+        # base metric required by SelectiveInferenceTask (will be wrapped by SelectiveMetric)
+        self.test_metrics = Accuracy(task="binary")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # predictions encoded in second column (0/1)
+        return x[:, 1].long()
+
+    def embed(self, x: torch.Tensor) -> torch.Tensor:
+        # expose input so the score can decide selection from the first column
+        return x
+
+
+class FlagScore(ConfidenceScore):
+    """Select if the first element of embedding equals 1.
+
+    Minimal implementation for tests: implements the abstract `fit` and
+    `score` methods from ConfidenceScore as no-ops / simple stubs so the
+    class can be instantiated. The test's selection logic still relies on
+    `select()` which inspects embeddings directly.
+    """
+
+    def fit(
+        self,
+        ref_embeddings: torch.Tensor,
+        val_embeddings: torch.Tensor | None = None,
+    ) -> None:
+        # no-op: store reference embeddings for completeness
+        self.ref_embeddings = ref_embeddings
+
+    def score(self, embeddings: torch.Tensor) -> torch.Tensor:
+        # return a dummy score vector (lower is better). Not used by select().
+        return torch.zeros(embeddings.shape[0], dtype=torch.float32)
+
+    def select(self, embeddings: torch.Tensor) -> dict[str, torch.Tensor]:
+        return {"selected": embeddings[:, 0].to(torch.bool)}
+
+
+class SmallDataset(Dataset):
+    def __init__(self):
+        # Each sample: [selected_flag, predicted_value], label
+        self.samples = [
+            ([1, 1], 1),  # selected, correct
+            ([1, 0], 0),  # selected, correct
+            ([0, 1], 0),  # rejected, incorrect
+            ([0, 0], 1),  # rejected, incorrect
+            ([0, 0], 0),  # rejected, correct
+        ]
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        x, y = self.samples[idx]
+        return {
+            "image": torch.tensor(x, dtype=torch.float32),
+            "label": torch.tensor(y, dtype=torch.long),
+        }
+
+
+class DM(LightningDataModule):
+    def test_dataloader(self):
+        # batch_size=3 -> produces batches of sizes 3 and 2 (uneven)
+        return DataLoader(SmallDataset(), batch_size=3, shuffle=False)
+
+
+def _find_metric(results: dict, suffix: str):
+    for k, v in results.items():
+        if k.endswith(suffix):
+            return float(v)
+    raise KeyError(suffix)
+
+
+def _tensor_dict_to_floats(d: dict) -> dict:
+    out = {}
+    for k, v in d.items():
+        try:
+            out[k] = float(v.item()) if hasattr(v, "item") else float(v)
+        except Exception:
+            out[k] = v
+    return out
+
+
+def test_selective_inference_trainer_integration(tmp_path):
+    task = DummyTask()
+    score = FlagScore()
+    sel_model = SelectiveInferenceTask(
+        task, score, input_key="image", target_key="label"
+    )
+
+    trainer = Trainer(
+        logger=False, enable_checkpointing=False, accelerator="cpu", devices=1
+    )
+
+    results = trainer.test(sel_model, datamodule=DM())
+
+    # trainer.test returns a list (one entry per test dataloader)
+    assert isinstance(results, list) and len(results) == 1
+    res = results[0]
+
+    # locate keys (lightning may prefix them with "test/")
+    reported_full = _find_metric(res, "full/BinaryAccuracy")
+    reported_selected = _find_metric(res, "selected/BinaryAccuracy")
+    reported_rejected = _find_metric(res, "rejected/BinaryAccuracy")
+
+    # Final computed dict from the SelectiveMetric inside the wrapper
+    metric_dict = sel_model.test_metrics.compute()
+    metric_floats = _tensor_dict_to_floats(metric_dict)
+
+    # Ensure trainer-reported values match the metric.compute() values
+    assert (
+        abs(
+            reported_full
+            - metric_floats.get("full/BinaryAccuracy", reported_full)
+        )
+        < 1e-6
+    )
+    assert (
+        abs(
+            reported_selected
+            - metric_floats.get("selected/BinaryAccuracy", reported_selected)
+        )
+        < 1e-6
+    )
+    assert (
+        abs(
+            reported_rejected
+            - metric_floats.get("rejected/BinaryAccuracy", reported_rejected)
+        )
+        < 1e-6
+    )
+
+    # Manual expected values for the dataset
+    # expected: selected accuracy = 2/2 = 1.0, full = 3/5 = 0.6, rejected = 1/3 ~= 0.333...
+    assert abs(metric_floats["selected/BinaryAccuracy"] - 1.0) < 1e-6
+    assert abs(metric_floats["full/BinaryAccuracy"] - 0.6) < 1e-6
+    assert abs(metric_floats["rejected/BinaryAccuracy"] - (1.0 / 3.0)) < 1e-6
+
+    # sanity: selected != full and rejected > 0
+    assert (
+        metric_floats["selected/BinaryAccuracy"]
+        != metric_floats["full/BinaryAccuracy"]
+    )
+    assert metric_floats["rejected/BinaryAccuracy"] > 0.0

--- a/tests/test_selective_integration.py
+++ b/tests/test_selective_integration.py
@@ -4,6 +4,7 @@ from lightning import LightningDataModule, LightningModule, Trainer
 from torch.utils.data import DataLoader, Dataset
 from torchmetrics import Accuracy
 
+from seapig import RiskCoverageMetric
 from seapig.model import SelectiveInferenceTask
 from seapig.scores.base import ConfidenceScore
 
@@ -47,7 +48,11 @@ class FlagScore(ConfidenceScore):
         return torch.zeros(embeddings.shape[0], dtype=torch.float32)
 
     def select(self, embeddings: torch.Tensor) -> dict[str, torch.Tensor]:
-        return {"selected": embeddings[:, 0].to(torch.bool)}
+        # boolean selection
+        selected = embeddings[:, 0].to(torch.bool)
+        # numeric score (lower is better) — include in outputs for RiskCoverageMetric
+        score = (1.0 - embeddings[:, 0].to(torch.float32)).reshape(-1)
+        return {"selected": selected, "score": score}
 
 
 class SmallDataset(Dataset):
@@ -156,3 +161,49 @@ def test_selective_inference_trainer_integration(tmp_path):
         != metric_floats["full/BinaryAccuracy"]
     )
     assert metric_floats["rejected/BinaryAccuracy"] > 0.0
+
+
+def test_risk_coverage_integration_via_trainer(tmp_path):
+    task = DummyTask()
+    score = FlagScore()
+    sel_model = SelectiveInferenceTask(
+        task, score, rc_metric=RiskCoverageMetric(risk="selective") ,input_key="image", target_key="label"
+    )
+
+    trainer = Trainer(
+        logger=False, enable_checkpointing=False, accelerator="cpu", devices=1
+    )
+
+    results = trainer.test(sel_model, datamodule=DM())
+
+    # trainer.test returns a list (one entry per test dataloader)
+    assert isinstance(results, list) and len(results) == 1
+    res = results[0]
+
+    # find reported values (Lightning may prefix them, so search by suffix)
+    reported_emp = _find_metric(res, "rc/auc_empirical")
+    reported_ref = _find_metric(res, "rc/auc_reference")
+    reported_excess = _find_metric(res, "rc/auc_excess")
+
+    # final computed dict from the RiskCoverageMetric on the model
+    metric_dict = sel_model.rc_metric.compute()
+    metric_floats = _tensor_dict_to_floats(metric_dict)
+
+    # Ensure trainer-reported values match metric.compute() values
+    assert abs(reported_emp - metric_floats.get("rc/auc_empirical", reported_emp)) < 1e-6
+    assert abs(reported_ref - metric_floats.get("rc/auc_reference", reported_ref)) < 1e-6
+    assert abs(reported_excess - metric_floats.get("rc/auc_excess", reported_excess)) < 1e-6
+
+    # Basic sanity checks on numeric ranges and presence
+    assert "rc/auc_empirical" in metric_floats
+    assert "rc/auc_reference" in metric_floats
+    assert "rc/auc_excess" in metric_floats
+
+    emp = metric_floats["rc/auc_empirical"]
+    ref = metric_floats["rc/auc_reference"]
+    excess = metric_floats["rc/auc_excess"]
+
+    assert 0.0 <= emp <= 1.0
+    assert 0.0 <= ref <= 1.0
+    # auc_excess can be slightly negative due to numeric differences; allow tiny tolerance
+    assert excess >= -1e-6


### PR DESCRIPTION
SelectiveMetric violated the torchmetrics/Lightning lifecycle by holding and sometimes reassigning internal Metric instances, while the LightningModule logged metric objects or per-batch computed scalars to Lightning. As a result Lightning either aggregated per-step scalars (averaging batch-wise accuracies) instead of using the epoch-level accumulated state, or computed/inspected Metric objects at times that skipped the SelectiveMetric's conditional update path. The internal selected submetric never received updates. 

Now we register child metrics/states as real torch.nn submodules, avoid reassigning .to() on registered modules, and emit final metrics (metric.compute()) at epoch end rather than logging per-batch computed values.