### PR TITLE
chore: add dependabot for actions and pip requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'pip'
+    directory: '/requirements'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Configured Dependabot to update GitHub Actions (weekly) and Python dependencies (daily).