### PR TITLE
feat: apply L2 normalization in EmbeddingScore

### DIFF
--- a/seapig/scores/embed.py
+++ b/seapig/scores/embed.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import torch
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from typing_extensions import override
 
@@ -53,10 +54,14 @@ class EmbeddingScore(ConfidenceScore, ABC):
     cal_embeddings: torch.Tensor | None
     train_required: bool = True
     pca: TensorPCA | None
+    normalize: bool = True
 
-    def __init__(self, pca: TensorPCA | None = None) -> None:
+    def __init__(
+        self, pca: TensorPCA | None = None, normalize: bool = True
+    ) -> None:
         super().__init__()
         self.pca = pca
+        self.normalize = normalize
         self.register_buffer("ref_embeddings", None)
         self.register_buffer("cal_embeddings", None, persistent=False)
 
@@ -102,7 +107,13 @@ class EmbeddingScore(ConfidenceScore, ABC):
         model: torch.nn.Module,
         loader: DataLoader[torch.Tensor | dict[str, torch.Tensor]],
     ) -> torch.Tensor:
-        """Load from file or iterate over dataloader to extract embeddings."""
+        """Load from file or iterate over dataloader to extract embeddings.
+
+        Normalizes embeddings with L2 norm by default (controlled by
+        `self.normalize`). When loading from disk, tensors are moved to the
+        model device and normalized. When embeddings are generated on-the-fly
+        they are normalized before being optionally written to disk.
+        """
         if path is not None and path.is_file():
             warnings.warn(
                 f"Loading pre-existing embeddings from {path}.", UserWarning
@@ -110,8 +121,12 @@ class EmbeddingScore(ConfidenceScore, ABC):
             v = self._load_pt(path)
             device = next(model.parameters()).device
             v = v.to(device)
+            if self.normalize:
+                v = F.normalize(v, p=2, dim=1)
         else:
             v = self._embed_dl(model=model, loader=loader)
+            if self.normalize:
+                v = F.normalize(v, p=2, dim=1)
             if path is not None:
                 self._write_pt(v, path)
         return v
@@ -279,6 +294,16 @@ class EmbeddingScore(ConfidenceScore, ABC):
             # Mode 1: Use precomputed embeddings
             self.ref_embeddings = X
             self.cal_embeddings = Y
+            # Apply optional L2-normalization to provided embeddings
+            if self.normalize:
+                if self.ref_embeddings is not None:
+                    self.ref_embeddings = F.normalize(
+                        self.ref_embeddings, p=2, dim=1
+                    )
+                if self.cal_embeddings is not None:
+                    self.cal_embeddings = F.normalize(
+                        self.cal_embeddings, p=2, dim=1
+                    )
         else:
             # Mode 2: Extract embeddings on-the-fly
             if model is None:
@@ -406,6 +431,8 @@ class EmbeddingScore(ConfidenceScore, ABC):
             assert X is not None, (
                 "X is required when using precomputed embeddings."
             )
+            if self.normalize:
+                X = F.normalize(X, p=2, dim=1)
             return self._score_embeddings(X)
         else:
             # Mode 2: Extract embeddings on-the-fly

--- a/seapig/scores/knn.py
+++ b/seapig/scores/knn.py
@@ -53,6 +53,9 @@ class KNNScore(EmbeddingScore, ABC):
     threshold:
         A `float` indicating the rejection threshold. Samples with scores higher
         than this threshold are excluded from prediction. Defaults to `None`.
+    normalize:
+        A `bool` indicating whether to L2-normalize embeddings before building
+        the index and scoring. Defaults to `True`.
     """
 
     k: int = 1
@@ -66,8 +69,9 @@ class KNNScore(EmbeddingScore, ABC):
         stat: str = "max",
         pca: TensorPCA | None = None,
         save_index: bool | Path = False,
+        normalize: bool = True,
     ) -> None:
-        super().__init__(pca=pca)
+        super().__init__(pca=pca, normalize=normalize)
         assert stat in ["max", "mean", "median", "min"]
         self.stat: str = stat
         self.k = k
@@ -353,6 +357,9 @@ class EuclideanScore(KNNScore):
         be used to perform dimensionality reduction on embeddings prior to
         scoring (for example, to retain a specified explained variance).
         Defaults to `None`, indicating that dimensionality reduction is not applied.
+    normalize:
+        A `bool` indicating whether to L2-normalize embeddings before building
+        the index and scoring. Defaults to `True`.
 
     Attributes
     ----------
@@ -376,8 +383,11 @@ class EuclideanScore(KNNScore):
         stat: str = "max",
         pca: TensorPCA | None = None,
         save_index: bool | Path = False,
+        normalize: bool = True,
     ) -> None:
-        super().__init__(k=k, stat=stat, pca=pca, save_index=save_index)
+        super().__init__(
+            k=k, stat=stat, pca=pca, save_index=save_index, normalize=normalize
+        )
 
     @override
     def _setup_index(self) -> None:
@@ -413,6 +423,9 @@ class CosineScore(KNNScore):
         be used to perform dimensionality reduction on embeddings prior to
         scoring (for example, to retain a specified explained variance).
         Defaults to `None`, indicating that dimensionality reduction is not applied.
+    normalize:
+        A `bool` indicating whether to L2-normalize embeddings before building
+        the index and scoring. Defaults to `True`.
 
     Attributes
     ----------
@@ -436,22 +449,22 @@ class CosineScore(KNNScore):
         stat: str = "max",
         pca: TensorPCA | None = None,
         save_index: bool | Path = False,
+        normalize: bool = True,
     ) -> None:
-        super().__init__(k=k, stat=stat, pca=pca, save_index=save_index)
+        super().__init__(
+            k=k, stat=stat, pca=pca, save_index=save_index, normalize=normalize
+        )
 
     @override
     def _setup_index(self) -> None:
         """Initialize an index based on reference embeddings."""
         assert isinstance(self.ref_embeddings, torch.Tensor)
-        normalized = torch.nn.functional.normalize(self.ref_embeddings)
-        self._build_index(normalized, space="cosinesimil")
+        self._build_index(self.ref_embeddings, space="cosinesimil")
 
     @override
     @torch.inference_mode()
     def _distance(self, query: torch.Tensor, kpn: int = 0) -> torch.Tensor:
-        assert self.index is not None
-        normalized = torch.nn.functional.normalize(query)
-        return self._query_index(normalized, kpn)
+        return self._query_index(query, kpn)
 
 
 class MahalanobisScore(KNNScore):
@@ -474,6 +487,9 @@ class MahalanobisScore(KNNScore):
         be used to perform dimensionality reduction on embeddings prior to
         scoring (for example, to retain a specified explained variance).
         Defaults to `None`, indicating that dimensionality reduction is not applied.
+    normalize:
+        A `bool` indicating whether to L2-normalize embeddings before building
+        the index and scoring. Defaults to `True`.
 
     Attributes
     ----------
@@ -498,8 +514,11 @@ class MahalanobisScore(KNNScore):
         stat: str = "max",
         pca: TensorPCA | None = None,
         save_index: bool | Path = False,
+        normalize: bool = True,
     ) -> None:
-        super().__init__(k=k, stat=stat, pca=pca, save_index=save_index)
+        super().__init__(
+            k=k, stat=stat, pca=pca, save_index=save_index, normalize=normalize
+        )
         self.register_buffer("vi_zero", None)
 
     @override

--- a/seapig/scores/pca.py
+++ b/seapig/scores/pca.py
@@ -26,14 +26,19 @@ class PCAScore(EmbeddingScore):
         be used to perform dimensionality reduction on embeddings prior to
         scoring (for example, to retain a specified explained variance).
         Defaults to `None`, indicating that dimensionality reduction is not applied.
+    normalize:
+        A `bool` indicating whether to L2-normalize the PCA-reduced embeddings.
+        Defaults to `True`.
     """
 
     ident = "pca"
 
     def __init__(
-        self, pca: TensorPCA = TensorPCA(n_components=0.50, gamma=3.0, M=4096)
+        self,
+        pca: TensorPCA = TensorPCA(n_components=0.50, gamma=3.0, M=4096),
+        normalize: bool = True,
     ) -> None:
-        super().__init__(pca=pca)
+        super().__init__(pca=pca, normalize=normalize)
 
     @override
     def fit(

--- a/seapig/scores/pyod.py
+++ b/seapig/scores/pyod.py
@@ -33,6 +33,9 @@ class PyODScore(EmbeddingScore):
         be used to perform dimensionality reduction on embeddings prior to
         scoring (for example, to retain a specified explained variance).
         Defaults to `None`, indicating that dimensionality reduction is not applied.
+    normalize:
+        A `bool` indicating whether to L2-normalize the PCA-reduced embeddings.
+        Defaults to `True`.
 
     Attributes
     ----------
@@ -53,9 +56,12 @@ class PyODScore(EmbeddingScore):
     ident: str = "pyod"
 
     def __init__(
-        self, detector: BaseDetector, pca: TensorPCA | None = None
+        self,
+        detector: BaseDetector,
+        pca: TensorPCA | None = None,
+        normalize: bool = True,
     ) -> None:
-        super().__init__(pca=pca)
+        super().__init__(pca=pca, normalize=normalize)
         self.detector = detector
         self.ident = f"{self.ident}-{detector.__class__.__name__}"
 

--- a/tests/test_fit_unified.py
+++ b/tests/test_fit_unified.py
@@ -46,6 +46,7 @@ class MinimalEmbedding(EmbeddingScore):
         super().__init__()
         self.train_required = False
         self.cal_required = False
+        self.normalize = False
 
     def _score_embeddings(self, X: torch.Tensor) -> torch.Tensor:
         return X.sum(dim=1)  # pragma: no cover

--- a/tests/test_knn.py
+++ b/tests/test_knn.py
@@ -273,3 +273,66 @@ def test_zeropad_warning_and_padding() -> None:
     assert out.shape == (1,)
     expected = torch.tensor([2.0])
     approx(out, expected)
+
+
+def test_normalize_flag_changes_distances() -> None:
+    """Ensure L2-normalization (default) is applied when enabled and alters distances.
+
+    We construct two reference vectors with very different norms so normalization
+    changes which is closer to the query. With refs [[10,0],[0,1]] and query
+    [1,0]:
+      - Without normalization: distances^2 -> [81, 2] -> min = 2
+      - With normalization: refs -> [1,0] and [0,1], query -> [1,0] -> min = 0
+    """
+    refs = torch.tensor([[10.0, 0.0], [0.0, 1.0]])
+    query = torch.tensor([[1.0, 0.0]])
+
+    # Ensure explicit behavior for both settings
+    score_no = EuclideanScore(k=1, stat="min", normalize=False)
+    score_no.fit(X=refs)
+    score_no._setup_index()
+    out_no = score_no._distance(query, kpn=0)
+
+    score_yes = EuclideanScore(k=1, stat="min", normalize=True)
+    score_yes.fit(X=refs)
+    score_yes._setup_index()
+    out_yes = score_yes._distance(query, kpn=0)
+
+    # squared distances expected
+    assert out_no.shape == out_yes.shape
+    assert out_no.item() == 2.0
+    assert out_yes.item() == 0.0
+
+
+@pytest.mark.filterwarnings(r"ignore:.*Loading pre-existing embeddings.*")
+def test_disk_loading_respects_works(tmp_path: "pathlib.Path") -> None:
+    """Embeddings loaded from disk are L2-normalized when prior normalized."""
+    # Create embeddings with different norms and save them
+    embs = torch.tensor([[10.0, 0.0], [0.0, 1.0]])
+    path = tmp_path / "embs.pt"
+    torch.save(embs, path)
+
+    # simple model to provide a device via next(model.parameters()).device
+    model = torch.nn.Linear(1, 1)
+
+    # loader argument is unused for the disk-load branch; provide a minimal DataLoader
+    from typing import cast
+
+    from torch.utils.data import DataLoader, TensorDataset
+
+    dataset = TensorDataset(torch.zeros(1, 1))
+    loader = cast(
+        DataLoader[torch.Tensor | dict[str, torch.Tensor]], DataLoader(dataset)
+    )
+
+    # Case 1: normalize = True -> norms should be ~1
+    score_yes = EuclideanScore(k=1, stat="min", normalize=True)
+    loaded_yes = score_yes._loadorembed(path, model, loader)
+    norms_yes = loaded_yes.norm(dim=1)
+    assert torch.allclose(norms_yes, torch.ones_like(norms_yes), atol=1e-6)
+
+    # Case 2: normalize = False -> norms are also ~1, since we saved normed embs
+    score_no = EuclideanScore(k=1, stat="min", normalize=False)
+    loaded_no = score_no._loadorembed(path, model, loader)
+    norms_no = loaded_no.norm(dim=1)
+    assert torch.allclose(norms_no, torch.ones_like(norms_yes), atol=1e-6)

--- a/tests/test_pyod.py
+++ b/tests/test_pyod.py
@@ -94,7 +94,7 @@ def test_score_uses_detector_decision_function() -> None:
             return result
 
     det = DetFn()
-    score = PyODScore(detector=det, pca=None)
+    score = PyODScore(detector=det, pca=None, normalize=False)
     # ensure detector present; no need to call _fit_impl for score()
     q = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
 


### PR DESCRIPTION
For `EmbeddingScore`-based scores, this PR adds L2 normalization which is enabled by default. This way, the behavior is more predictable since scores behave the same way (prior to this, EuclideanScore did not normalize, while we normalized in CosineScore), and TensorPCA also applies normalization. Users can opt-out of feature normalization because the argument is forwarded to the concrete implementations. 