### PR TITLE
Re-work risk-coverage

### DIFF
--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -240,8 +240,6 @@ class RiskCoverageMetric(Metric):
             self._error_metric = error_metric
             self._metric_names = [str(k) for k in self._error_metric.keys()]
 
-        self._sanity_check()
-
         # Metric states (concatenate across steps)
         self.add_state(
             "scores",
@@ -266,27 +264,6 @@ class RiskCoverageMetric(Metric):
         # Last computed curve(s) (non‑tensor; kept for retrieval only)
         self._last_curve: RiskCoverage | None = None
         self._last_curves: dict[str, RiskCoverage] | None = None
-
-    def _sanity_check(self) -> None:
-        """Sanity check that the provided ``error_metric`` produces valid per‑sample residuals.
-
-        The check is only performed when a ``MetricCollection`` is supplied.  When
-        ``error_metric`` is ``None`` (legacy ``error_fn`` path) the method exits
-        early – the legacy path does not rely on this validation.
-        """
-        if self._error_metric is None:
-            return
-
-        dummy_preds = torch.randn(2, 3)
-        dummy_target = torch.randn(2, 3)
-        self._error_metric.update(dummy_preds, dummy_target)
-        residuals = self._error_metric.compute()
-        self._error_metric.reset()
-
-        if isinstance(residuals, dict):
-            # Validate each metric's residual tensor individually.
-            for name, val in residuals.items():
-                residuals[name] = self._validate_tensor(val, name)
 
     @staticmethod
     def _validate_tensor(

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -263,8 +263,9 @@ class RiskCoverageMetric(Metric):
                 dist_reduce_fx="cat",
             )
 
-        # Last computed curve (non‑tensor; kept for retrieval only)
+        # Last computed curve(s) (non‑tensor; kept for retrieval only)
         self._last_curve: RiskCoverage | None = None
+        self._last_curves: dict[str, RiskCoverage] | None = None
 
     def _sanity_check(self) -> None:
         """Sanity check that the provided ``error_metric`` produces valid per‑sample residuals.
@@ -397,31 +398,66 @@ class RiskCoverageMetric(Metric):
             else:
                 self.residuals = torch.cat([self.residuals, residuals], dim=0)
 
+    def _compute_curves(self) -> dict[str, RiskCoverage]:
+        """Build risk-coverage curves from the accumulated state.
+
+        Returns a mapping from metric name to `RiskCoverage`. When no
+        `error_metric` was provided, the single legacy curve is returned
+        under the key `"__default__"`.
+        """
+        if self.scores.numel() == 0:
+            return {}
+
+        if not self._metric_names:
+            return {
+                "__default__": risk_coverage(
+                    score=self.scores,
+                    residuals=self.residuals,
+                    risk=self.risk,
+                    n_bins=self.n_bins,
+                )
+            }
+
+        curves: dict[str, RiskCoverage] = {}
+        for name in self._metric_names:
+            curves[name] = risk_coverage(
+                score=self.scores,
+                residuals=getattr(self, f"residuals_{name}"),
+                risk=self.risk,
+                n_bins=self.n_bins,
+            )
+        return curves
+
     def compute(self) -> dict[str, torch.Tensor]:
         """Compute AUC summaries for the accumulated risk--coverage curve.
 
         Returns a dict with keys `rc/auc_empirical`, `rc/auc_reference`,
-        and `rc/auc_excess`. If no data has been accumulated an all-zero
-        mapping is returned on the correct device.
+        and `rc/auc_excess`. If multiple residual streams are present,
+        results are prefixed with the corresponding metric name.
         """
         if self.scores.numel() == 0:
-            # No data yet; return zeros on the registered device
             zero = torch.tensor(0.0, device=self.scores.device)
-            return {
-                "rc/auc_empirical": zero,
-                "rc/auc_reference": zero,
-                "rc/auc_excess": zero,
-            }
+            if not self._metric_names:
+                return {
+                    "rc/auc_empirical": zero,
+                    "rc/auc_reference": zero,
+                    "rc/auc_excess": zero,
+                }
+
+            results: dict[str, torch.Tensor] = {}
+            for name in self._metric_names:
+                prefix = f"rc/{name}"
+                results[f"{prefix}/auc_empirical"] = zero
+                results[f"{prefix}/auc_reference"] = zero
+                results[f"{prefix}/auc_excess"] = zero
+            return results
 
         device = self.scores.device
-        # If no per‑metric names were defined, fall back to the original behaviour.
+        curves = self._compute_curves()
+        self._last_curves = curves
+
         if not self._metric_names:
-            rc = risk_coverage(
-                score=self.scores,
-                residuals=self.residuals,
-                risk=self.risk,
-                n_bins=self.n_bins,
-            )
+            rc = curves["__default__"]
             self._last_curve = rc
             return {
                 "rc/auc_empirical": torch.as_tensor(
@@ -433,16 +469,9 @@ class RiskCoverageMetric(Metric):
                 "rc/auc_excess": torch.as_tensor(rc.auc_excess, device=device),
             }
 
-        # Multi‑metric case: compute a curve for each metric separately.
         results: dict[str, torch.Tensor] = {}
-        for name in self._metric_names:
-            residuals = getattr(self, f"residuals_{name}")
-            rc = risk_coverage(
-                score=self.scores,
-                residuals=residuals,
-                risk=self.risk,
-                n_bins=self.n_bins,
-            )
+        last_curve: RiskCoverage | None = None
+        for name, rc in curves.items():
             prefix = f"rc/{name}"
             results[f"{prefix}/auc_empirical"] = torch.as_tensor(
                 rc.auc_empirical, device=device
@@ -453,13 +482,22 @@ class RiskCoverageMetric(Metric):
             results[f"{prefix}/auc_excess"] = torch.as_tensor(
                 rc.auc_excess, device=device
             )
-        # Store the last curve (from the last metric) for ``get_curve`` compatibility.
-        self._last_curve = rc
+            last_curve = rc
+
+        self._last_curve = last_curve
         return results
 
-    def get_curve(self) -> RiskCoverage | None:
-        """Return the last computed RiskCoverage object (or None if not computed)."""
-        return self._last_curve
+    def get_curve(
+        self, metric_name: str | None = None
+    ) -> RiskCoverage | dict[str, RiskCoverage] | None:
+        """Return the last computed curve(s), or None if not computed yet."""
+        if self._last_curves is None:
+            return None
+        if metric_name is not None:
+            return self._last_curves[metric_name]
+        if len(self._last_curves) == 1:
+            return next(iter(self._last_curves.values()))
+        return self._last_curves
 
     def reset(self) -> None:
         """Reset all accumulated state.
@@ -485,3 +523,4 @@ class RiskCoverageMetric(Metric):
                 ),
             )
         self._last_curve = None
+        self._last_curves = None

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -251,8 +251,10 @@ class SelectiveInferenceTask(LightningModule):
         selection = self._select(x)
         return preds | selection
 
-    def get_risk_coverage_curve(self) -> RiskCoverage | None:
-        """Return the latest computed risk-coverage curve, or None if not available."""
+    def get_risk_coverage_curve(
+        self,
+    ) -> RiskCoverage | dict[str, RiskCoverage] | None:
+        """Return the latest computed risk-coverage curve(s), or None if not available."""
         if self.rc_metric is None:
             return None
         return self.rc_metric.get_curve()

--- a/seapig/risk.py
+++ b/seapig/risk.py
@@ -242,11 +242,8 @@ def risk_coverage(
         msg = f"risk must be 'generalized' or 'selective', got '{risk}'"
         raise ValueError(msg)
 
-    assert risk in ["generalized", "selective"], (
-        "risk must be 'generalized' or 'selective'"
-    )
     device = score.device
-    residuals.to(device=device)
+    residuals = residuals.to(device=device)
 
     # Calculate empirical risk-coverage curve
     coverage_emp, threshold_emp, risk_emp = _rc_curve(score, residuals, risk)
@@ -292,7 +289,7 @@ def _rc_curve(
     """
     # Sort by score (descending, so we reject highest scores first)
     device = score.device
-    order = torch.argsort(score, descending=True)
+    order = torch.argsort(score, descending=False)
     score_sorted = score[order]
     residuals_sorted = residuals[order]
 

--- a/tests/test_metric_risk_coverage.py
+++ b/tests/test_metric_risk_coverage.py
@@ -345,35 +345,6 @@ def test_multi_metric_support_and_sanity_check() -> None:
         assert f"{prefix}/auc_excess" in out
 
 
-def test_sanity_check_invalid_residual_shape() -> None:
-    """The sanity check should raise if a metric returns a non‑1‑D tensor.
-
-    We construct a dummy metric that returns a 2‑D tensor to trigger the
-    validation error.
-    """
-
-    class BadMetric(Metric):
-        def __init__(self) -> None:
-            super().__init__()
-            self.add_state(
-                "value",
-                default=torch.tensor([], dtype=torch.float32),
-                dist_reduce_fx="cat",
-            )
-
-        def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
-            # Return a 2‑D tensor deliberately.
-            self.value = torch.stack([preds, target])
-
-        def compute(self) -> torch.Tensor:
-            return self.value
-
-    bad = BadMetric()
-    coll = MetricCollection(bad)
-    with pytest.raises(ValueError, match="must return a 1‑D tensor"):
-        RiskCoverageMetric(error_metric=coll)
-
-
 def test_validate_tensor_cases() -> None:
     """Validate that `_validate_tensor` accepts (B,) and (B,1) and rejects others."""
 

--- a/tests/test_metric_risk_coverage.py
+++ b/tests/test_metric_risk_coverage.py
@@ -1,10 +1,12 @@
 import math
+from typing import cast
 
 import pytest
 import torch
 from torchmetrics import Metric, MetricCollection
 
 from seapig.metric import RiskCoverageMetric
+from seapig.risk import RiskCoverage
 
 
 # Create a collection with two simple custom error metrics.
@@ -38,6 +40,78 @@ class SqErrorMetric(Metric):
 
     def compute(self) -> torch.Tensor:
         return self.res
+
+
+def test_get_curve_multi_metric():
+    coll = MetricCollection({"mae": AbsErrorMetric(), "mse": SqErrorMetric()})
+    metric = RiskCoverageMetric(error_metric=coll)
+    preds = torch.tensor([[0.5, 0.2], [0.1, 0.9]])
+    target = torch.tensor([[0.0, 0.0], [0.0, 1.0]])
+    scores = torch.tensor([0.1, 0.2])
+    metric.update(preds=preds, target=target, scores=scores)
+    metric.compute()
+    curves = metric.get_curve()
+    assert isinstance(curves, dict)
+    curves = cast(dict[str, RiskCoverage], curves)
+    assert set(curves) == {"mae", "mse"}
+    assert all(hasattr(curve, "auc_empirical") for curve in curves.values())
+    assert metric.get_curve("mae") is curves["mae"]
+
+
+def test_get_curve_single_metric():
+    metric = RiskCoverageMetric(error_metric=AbsErrorMetric())
+    preds = torch.tensor([0.5, 0.6])
+    target = torch.tensor([0.0, 1.0])
+    scores = torch.tensor([0.2, 0.4])
+    metric.update(preds=preds, target=target, scores=scores)
+    metric.compute()
+    curve = metric.get_curve()
+    assert hasattr(curve, "auc_empirical")
+
+
+def test_get_curve_none_before_compute_and_after_reset():
+    metric = RiskCoverageMetric(error_metric=AbsErrorMetric())
+    assert metric.get_curve() is None
+    preds = torch.tensor([0.5, 0.6])
+    target = torch.tensor([0.0, 1.0])
+    scores = torch.tensor([0.2, 0.4])
+    metric.update(preds=preds, target=target, scores=scores)
+    metric.compute()
+    assert metric.get_curve() is not None
+    metric.reset()
+    assert metric.get_curve() is None
+
+
+def test_compute_output_keys_multi_metric():
+    coll = MetricCollection({"mae": AbsErrorMetric(), "mse": SqErrorMetric()})
+    metric = RiskCoverageMetric(error_metric=coll)
+    preds = torch.tensor([[0.5, 0.2], [0.1, 0.9]])
+    target = torch.tensor([[0.0, 0.0], [0.0, 1.0]])
+    scores = torch.tensor([0.1, 0.2])
+    metric.update(preds=preds, target=target, scores=scores)
+    out = metric.compute()
+    for metric_name in ("mae", "mse"):
+        prefix = f"rc/{metric_name}"
+        for suffix in ("auc_empirical", "auc_reference", "auc_excess"):
+            assert f"{prefix}/{suffix}" in out
+            assert isinstance(out[f"{prefix}/{suffix}"], torch.Tensor)
+
+
+def test_reset_clears_curves_and_buffers():
+    coll = MetricCollection({"mae": AbsErrorMetric(), "mse": SqErrorMetric()})
+    metric = RiskCoverageMetric(error_metric=coll)
+    preds = torch.tensor([[0.5, 0.2], [0.1, 0.9]])
+    target = torch.tensor([[0.0, 0.0], [0.0, 1.0]])
+    scores = torch.tensor([0.1, 0.2])
+    metric.update(preds=preds, target=target, scores=scores)
+    metric.compute()
+    assert metric.get_curve() is not None
+    metric.reset()
+    assert metric.get_curve() is None
+    assert metric.scores.numel() == 0
+    assert metric.residuals.numel() == 0
+    assert metric.residuals_mae.numel() == 0  # type: ignore[operator, ty:call-non-callable]
+    assert metric.residuals_mse.numel() == 0  # type: ignore[operator, ty:call-non-callable]
 
 
 @pytest.mark.parametrize("risk", ["generalized", "selective"])

--- a/tests/test_metric_risk_coverage.py
+++ b/tests/test_metric_risk_coverage.py
@@ -114,6 +114,21 @@ def test_reset_clears_curves_and_buffers():
     assert metric.residuals_mse.numel() == 0  # type: ignore[operator, ty:call-non-callable]
 
 
+def test_risk_coverage_metric_empty_with_metric_names():
+    metric = RiskCoverageMetric(error_metric=AbsErrorMetric())
+    # expect a warning here because compute is called before any updates
+    with pytest.warns(UserWarning, match="was called before"):
+        result = metric.compute()
+    # Should return zero tensors for each metric key
+    assert all(v.item() == 0.0 for v in result.values())
+    # Should include keys for the metric
+    assert set(result.keys()) == {
+        "rc/AbsErrorMetric/auc_empirical",
+        "rc/AbsErrorMetric/auc_reference",
+        "rc/AbsErrorMetric/auc_excess",
+    }
+
+
 @pytest.mark.parametrize("risk", ["generalized", "selective"])
 def test_risk_coverage_metric_basic_functionality(risk: str) -> None:
     metric = RiskCoverageMetric(risk=risk)


### PR DESCRIPTION
Now allows supplying multiple metrics. Also inverts ordering ensuring highest values are rejected first (-> uncertainty scores)