### PR TITLE
docs: uses uncertainty vocabulary instead of confidence-based vocab

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 ------------------------------------------------------------------------
 
-seapig provides confidence-based selective inference for deep learning
+seapig provides uncertainty-based selective inference for deep learning
 models. Its main focus currently lies on analyzing latent
 representations. The library implements a small set of lightweight,
-composable confidence scores that are used to decide whether to accept
-or reject an individual query sample at prediction time. Thresholds are
-calibrated on an independent validation set. It provides a wrapper for
-torchmetrics that allows evaluating the performance of a selective
-inference system on a test set, and a PyTorch Lightning task for
-seamless integration into training and evaluation pipelines.
+composable uncertainty scores that are used to decide whether to accept
+or reject an individual query sample at prediction time. Samples with
+Thresholds are calibrated on an independent validation set. It provides
+a wrapper for torchmetrics that allows evaluating the performance of a
+selective inference system on a test set, and a PyTorch Lightning task
+for seamless integration into training and evaluation pipelines.
 
 ### Installation
 
@@ -34,7 +34,7 @@ pip install seapig
 pip install seapig[suggested]
 
 # for contributors / developers (tests, linters, type-checkers)
-pip install seapig[dev]  # uses ty for type checking
+pip install seapig[dev]
 # for building documentation (quarto-cli, great-docs, others)
 pip install seapig[docs]
 # or, if you need everything:
@@ -54,9 +54,9 @@ The core idea is to compute a representation for each input, score how
 similar the representation is to training representations, and reject
 inputs whose score indicates low support.
 
-### From confidence scores to selective inference
+### From uncertainty scores to selective inference
 
-All confidence scores produce a scalar score $s(x)$ for each query $x$.
+All uncertainty scores produce a scalar score $s(x)$ for each query $x$.
 Given a threshold $\lambda$, we derive a binary selection function
 indicating which samples to accept. For example, accepting samples with
 score below $\lambda$:

--- a/docs/02-quickstart.qmd
+++ b/docs/02-quickstart.qmd
@@ -275,12 +275,12 @@ trainer.fit(model, train_dl, val_dl)
 
 ## Step 4: Fit and calibrate a score {#sec-step-4}
 
-Here's where `seapig` comes in. A **selection score** quantifies how confident 
+Here's where `seapig` comes in. A **selection score** quantifies how uncertain 
 the model is in each prediction. We use `CosineScore`, which measures the 
 distance between a query embedding and its nearest neighbor in the training 
-embedding space. Lower scores indicate higher confidence (similar to training data),
-while higher scores indicate the model has encountered something unfamiliar 
-(potential uncertainty).
+embedding space. Lower scores indicate that a sample is similar to training data
+(lower uncertainty), while higher scores indicate the model has encountered 
+something unfamiliar (higher uncertainty).
 
 We fit the score on both training and validation data, so it learns what "normal" 
 and "unusual" look like. Then we set a threshold at the 80th percentile of the 

--- a/great-docs.yml
+++ b/great-docs.yml
@@ -66,8 +66,8 @@ reference:
           - get_curve
       - RiskCoverage
 
-  - title: Embedding based Confidence Scores
-    desc: Confidence scoring methods for embedding-based approaches
+  - title: Embedding based Uncertainty Scores
+    desc: Uncertainty scoring methods for embedding-based approaches
     contents:
       - name: scores.CosineScore
         members:
@@ -119,8 +119,8 @@ reference:
           - plot_embs
       - scores.utils.TensorPCA
     
-  - title: Logit based Confidence Scores
-    desc: Confidence scoring methods based on model logits
+  - title: Logit based Uncertainty Scores
+    desc: Uncertainty scoring methods based on model logits
     contents:
       - name: scores.EnergyScore
         members:
@@ -155,8 +155,8 @@ reference:
           - get_threshold
           - plot
 
-  - title: Other Confidence Scores
-    desc: Confidence scoring methods based on other principles
+  - title: Other Uncertainty Scores
+    desc: Uncertainty scoring methods based on other principles
     contents:
       - name: scores.RandomScore
         members:
@@ -167,7 +167,7 @@ reference:
   - title: Abstract Classes
     desc: Abstract base classes
     contents:
-      - name: scores.ConfidenceScore
+      - name: scores.UncertaintyScore
       - scores.EmbeddingScore
       - scores.KNNScore
       - scores.LogitScore

--- a/index.qmd
+++ b/index.qmd
@@ -5,11 +5,11 @@
 
 ---
 
-seapig provides confidence-based selective inference for deep learning
+seapig provides uncertainty-based selective inference for deep learning
 models. Its main focus currently lies on analyzing latent representations. 
-The library implements a small set of lightweight, composable confidence scores 
+The library implements a small set of lightweight, composable uncertainty scores 
 that are used to decide whether to accept or reject an individual query sample 
-at prediction time. Thresholds are calibrated on an independent validation
+at prediction time. Samples with  Thresholds are calibrated on an independent validation
 set. It provides a wrapper for torchmetrics that allows evaluating the performance 
 of a selective inference system on a test set, and a PyTorch Lightning task for 
 seamless integration into training and evaluation pipelines.
@@ -49,9 +49,9 @@ The core idea is to compute a representation for each input, score how
 similar the representation is to training representations, and reject inputs 
 whose score indicates low support.
 
-### From confidence scores to selective inference
+### From uncertainty scores to selective inference
 
-All confidence scores produce a scalar score $s(x)$ for each query
+All uncertainty scores produce a scalar score $s(x)$ for each query
 $x$. Given a threshold $\lambda$, we derive a binary selection function 
 indicating which samples to accept. For example, accepting
 samples with score below $\lambda$:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "seapig"
-description = "Selective prediction based on confidence scores"
+description = "Selective prediction based on uncertainty scores"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
 license = "MIT"
@@ -18,7 +18,7 @@ authors = [
 maintainers = [
     {name = "Darius A. Görgen", email = "info@dariusgoergen.com"},
 ]
-keywords = ["pytorch", "remote sensing", "area of applicability", "confidence scoring", "selective prediction"]
+keywords = ["pytorch", "remote sensing", "area of applicability", "uncertainty scoring", "confidence scoring", "selective prediction"]
 
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/seapig/metric.py
+++ b/seapig/metric.py
@@ -1,7 +1,7 @@
 """Metrics helpers for selective evaluation.
 
 This module provides two utilities used during evaluation when a model
-can abstain or return confidence scores:
+can abstain or return uncertainty scores:
 
 - `SelectiveMetric`: wraps a `torchmetrics.Metric` (or a
   `torchmetrics.MetricCollection`) and tracks the metric on three
@@ -312,7 +312,7 @@ class RiskCoverageMetric(Metric):
             Model outputs and targets. These are passed to `error_fn` to
             compute per-sample residuals.
         scores : torch.Tensor
-            Per-sample confidence scores (lower values indicate higher confidence).
+            Per-sample uncertainty scores (lower values indicate lower uncertainty).
         """
         device = preds.device
         scores = scores.to(device)

--- a/seapig/model.py
+++ b/seapig/model.py
@@ -1,8 +1,8 @@
-"""Selective inference wrapper combining a LightningModule with a ConfidenceScore.
+"""Selective inference wrapper combining a LightningModule with a UncertaintyScore.
 
 This module provides SelectiveInferenceTask, a thin wrapper that runs a pre-trained
-LightningModule in inference mode, computes a confidence/selection score from the
-model's embeddings using a ConfidenceScore, and returns predictions augmented with
+LightningModule in inference mode, computes a uncertainty score from the
+model's embeddings using a UncertaintyScore, and returns predictions augmented with
 selection results. The wrapper can also update and log selective metrics during
 testing.
 """
@@ -17,7 +17,7 @@ from torchmetrics import Metric, MetricCollection
 
 from seapig.metric import RiskCoverageMetric, SelectiveMetric
 from seapig.risk import RiskCoverage
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 
 INPUT_KEYS = Literal["image", "input", "images", "inputs", "x"]
 TARGET_KEYS = Literal[
@@ -29,7 +29,7 @@ class SelectiveInferenceTask(LightningModule):
     """Wrap a trained `LightningModule` to attach selection results during inference.
 
     The wrapper calls the wrapped model in inference mode and combines its
-    predictions with selection outputs produced by a provided `ConfidenceScore`.
+    predictions with selection outputs produced by a provided `UncertaintyScore`.
 
     Key behavior:
 
@@ -50,7 +50,7 @@ class SelectiveInferenceTask(LightningModule):
         A trained `LightningModule` whose `forward(x)` returns predictions. The
         module must implement `embed(x)` to produce embeddings for scoring.
     score
-        A seapig `ConfidenceScore` instance providing the `ConfidenceScore.select` method.
+        A seapig `UncertaintyScore` instance providing the `UncertaintyScore.select` method.
     input_key
         Key used to extract inputs from an incoming batch. If `None` (default),
         the first element of the batch is used (positional index 0). When a
@@ -85,7 +85,7 @@ class SelectiveInferenceTask(LightningModule):
     def __init__(
         self,
         task: LightningModule,
-        score: ConfidenceScore,
+        score: UncertaintyScore,
         acc_test_outputs: bool = False,
         input_key: INPUT_KEYS | None = None,
         target_key: TARGET_KEYS | None = None,
@@ -97,8 +97,8 @@ class SelectiveInferenceTask(LightningModule):
         )
         self.task = copy.deepcopy(task)
         self.task.eval()  # Keep the wrapped task in evaluation mode
-        assert isinstance(score, ConfidenceScore), (
-            "score must be a seapig ConfidenceScore instance"
+        assert isinstance(score, UncertaintyScore), (
+            "score must be a seapig UncertaintyScore instance"
         )
         self.score = score
         if input_key is not None and input_key not in get_args(INPUT_KEYS):

--- a/seapig/risk.py
+++ b/seapig/risk.py
@@ -181,7 +181,7 @@ def risk_coverage(
 ) -> RiskCoverage:
     """Compute risk-coverage curves and AUCs for a selective predictor.
 
-    Given a score (confidence) and corresponding residuals (prediction
+    Given a score (uncertainty) and corresponding residuals (prediction
     errors), this function returns a `RiskCoverage` object containing:
 
     - empirical risk curve (model scores)
@@ -192,7 +192,7 @@ def risk_coverage(
     Parameters
     ----------
     score : `torch.Tensor`
-        Confidence scores. Lower values indicate higher confidence.
+        Uncertainty scores. Lower values indicate lower uncertainty.
         Must have the same length as `residuals`.
     residuals : `torch.Tensor`
         Prediction residuals (errors). Lower values indicate better

--- a/seapig/scores/__init__.py
+++ b/seapig/scores/__init__.py
@@ -1,6 +1,6 @@
-"""Confidence Scores supplied by seapig."""
+"""Uncertainty Scores supplied by seapig."""
 
-from seapig.scores.base import ConfidenceScore, RandomScore
+from seapig.scores.base import RandomScore, UncertaintyScore
 from seapig.scores.embed import EmbeddingScore
 from seapig.scores.knn import (
     CosineScore,
@@ -18,7 +18,7 @@ from seapig.scores.logits import (
 from seapig.scores.pca import PCAScore
 
 __all__ = [
-    "ConfidenceScore",
+    "UncertaintyScore",
     "EmbeddingScore",
     "KNNScore",
     "LogitScore",

--- a/seapig/scores/base.py
+++ b/seapig/scores/base.py
@@ -1,4 +1,4 @@
-"""Base Classes for Confidence Scores."""
+"""Base Classes for Uncertainty Scores."""
 
 from abc import ABC, abstractmethod
 from typing import Any
@@ -12,10 +12,10 @@ from seapig.utils import get_logger
 logger = get_logger(__name__)
 
 
-class ConfidenceScore(torch.nn.Module, ABC):
-    """Abstract Base Class for Confidence Scores.
+class UncertaintyScore(torch.nn.Module, ABC):
+    """Abstract Base Class for Uncertainty Scores.
 
-    Confidence scores quantify the deviation of query samples from the training
+    Uncertainty scores quantify the deviation of query samples from the training
     distribution. Low scores indicate likely inliers (samples similar to training),
     while high scores indicate likely outliers (samples deviating from training).
     Samples with scores exceeding the threshold are excluded from prediction.
@@ -31,7 +31,7 @@ class ConfidenceScore(torch.nn.Module, ABC):
     calibrated : bool
         Whether the score has been calibrated. Defaults to `False`.
     scores : torch.Tensor or None
-        Confidence scores of the calibration samples. Low scores indicate
+        Uncertainty scores of the calibration samples. Low scores indicate
         likely inliers, high scores indicate likely outliers.
     threshold : torch.Tensor or None
         Rejection threshold. Samples with scores higher than this value are
@@ -39,7 +39,7 @@ class ConfidenceScore(torch.nn.Module, ABC):
     device : str
         Device to which internal tensors are put. Defaults to `"cpu"`.
     ident : str
-        String identifying the confidence score implementation.
+        String identifying the uncertainty score implementation.
 
     See Also
     --------
@@ -117,7 +117,7 @@ class ConfidenceScore(torch.nn.Module, ABC):
 
     @abstractmethod
     def fit(self, *args: Any, **kwargs: Any) -> None:
-        """Fit a confidence score on training data.
+        """Fit an uncertainty score on training data.
 
         `X` is used as training samples to fit the underlying method,
         while `Y` is an optional parameter that can be used to compute
@@ -129,7 +129,7 @@ class ConfidenceScore(torch.nn.Module, ABC):
 
     @abstractmethod
     def score(self, *args: Any, **kwargs: Any) -> torch.Tensor:
-        """Calculate the confidence score for a tensor of samples.
+        """Calculate the uncertainty score for a tensor of samples.
 
         Returns scores where low values indicate likely inliers and high values
         indicate likely outliers.
@@ -137,7 +137,7 @@ class ConfidenceScore(torch.nn.Module, ABC):
 
     @abstractmethod
     def select(self, *args: Any, **kwargs: Any) -> dict[str, torch.Tensor]:
-        """Select samples for prediction based on their confidence score.
+        """Select samples for prediction based on their uncertainty score.
 
         Samples with scores lower than the threshold are selected for prediction,
         while samples with scores higher than the threshold are excluded.
@@ -145,16 +145,16 @@ class ConfidenceScore(torch.nn.Module, ABC):
         Returns
         -------
         dict[str, torch.Tensor]
-            A dict with keys `'score'` (raw confidence scores) and
+            A dict with keys `'score'` (raw uncertainty scores) and
             `'selected'` (boolean selection mask).
         """
 
     def plot(
         self, query_scores: torch.Tensor | None = None, bins: int = 100
     ) -> None:
-        """Plot densities for confidence scores.
+        """Plot densities for uncertainty scores.
 
-        By default, this method plots densities for the confidence scores.
+        By default, this method plots densities for the uncertainty scores.
         Optionally, it can also plot densities for `query_scores`.
 
         Parameters
@@ -242,8 +242,8 @@ class ConfidenceScore(torch.nn.Module, ABC):
             )
 
         # Add labels and legend
-        plt.title("Confidence Score Densities")
-        plt.xlabel("Confidence Score")
+        plt.title("Uncertainty Score Densities")
+        plt.xlabel("Uncertainty Score")
         plt.ylabel("Density")
         plt.legend()
         plt.grid(True, linestyle="--", alpha=0.6)
@@ -252,18 +252,17 @@ class ConfidenceScore(torch.nn.Module, ABC):
         plt.show()
 
 
-class RandomScore(ConfidenceScore):
-    """Returns random confidence scores per sample.
+class RandomScore(UncertaintyScore):
+    """Returns random uncertainty scores per sample.
 
     This score assigns a random float in `[0, 1]` to each sample.
-    It is useful as a baseline or for testing purposes. Low scores
-    indicate likely inliers, high scores indicate likely outliers.
+    It is useful as a baseline or for testing purposes.
     By default, the threshold is set to `0.99`, so approximately
     99% of samples are selected.
 
     See Also
     --------
-    `scores.ConfidenceScore`
+    `scores.UncertaintyScore`
     """
 
     train_required: bool = False
@@ -284,7 +283,7 @@ class RandomScore(ConfidenceScore):
     @override
     @torch.inference_mode()
     def score(self, X: torch.Tensor) -> torch.Tensor:
-        """Compute a random confidence score for every sample in a batch.
+        """Compute a random uncertainty score for every sample in a batch.
 
         Returns random scores where low values indicate likely inliers and
         high values indicate likely outliers.
@@ -313,7 +312,7 @@ class RandomScore(ConfidenceScore):
     @override
     @torch.inference_mode()
     def select(self, X: torch.Tensor) -> dict[str, torch.Tensor]:
-        """Select samples for prediction based on their random confidence score.
+        """Select samples for prediction based on their random uncertainty score.
 
         Samples with scores lower than the threshold are selected for prediction.
 

--- a/seapig/scores/embed.py
+++ b/seapig/scores/embed.py
@@ -1,4 +1,4 @@
-"""Abstract Base Method for embeddings based confidence scores."""
+"""Abstract Base Method for embeddings based uncertainty scores."""
 
 import inspect
 import warnings
@@ -10,7 +10,7 @@ import torch
 from torch.utils.data import DataLoader
 from typing_extensions import override
 
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 from seapig.scores.utils import TensorPCA
 from seapig.utils import get_logger
 from seapig.utils.progress import track
@@ -18,8 +18,8 @@ from seapig.utils.progress import track
 logger = get_logger(__name__)
 
 
-class EmbeddingScore(ConfidenceScore, ABC):
-    """Base class for embedding-based confidence scores.
+class EmbeddingScore(UncertaintyScore, ABC):
+    """Base class for embedding-based uncertainty scores.
 
     Embedding-based scores quantify deviation from the training distribution using
     latent-space embeddings. Low scores indicate samples similar to the training
@@ -40,13 +40,13 @@ class EmbeddingScore(ConfidenceScore, ABC):
     cal_embeddings : torch.Tensor or None
         Embeddings of validation/calibration samples. Optional.
     scores : torch.Tensor or None
-        Confidence scores of the calibration (or training) samples.
+        Uncertainty scores of the calibration (or training) samples.
     threshold : torch.Tensor or None
         Rejection threshold. Samples with scores above this value are excluded.
 
     See Also
     --------
-    `scores.ConfidenceScore`
+    `scores.UncertaintyScore`
     `scores.KNNScore`
     `scores.PCAScore`
     `scores.PyODScore`
@@ -79,7 +79,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
 
     @staticmethod
     def _check_model(model: torch.nn.Module) -> None:
-        """Check a model for compatibility with embeddings-based confidence scores."""
+        """Check a model for compatibility with embeddings-based uncertainty scores."""
         assert isinstance(model, torch.nn.Module)
         if not callable(model.embed):
             raise Exception("model is required to have a `.embed()` method.")
@@ -228,7 +228,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         outdir: Path | None = None,
         prefix: str | None = None,
     ) -> None:
-        """Train a confidence score based on sample embeddings.
+        """Train a uncertainty score based on sample embeddings.
 
         This method supports two usage modes:
 
@@ -319,7 +319,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
 
     @override
     def set_threshold(self, q: float = 0.99) -> None:
-        """Set a threshold based on a quantile of the available confidence scores.
+        """Set a threshold based on a quantile of the available uncertainty scores.
 
         Samples with scores higher than the threshold are excluded from prediction.
         If calibration embeddings were provided during `fit`, the threshold is
@@ -348,7 +348,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         outdir: Path | None = None,
         prefix: str | None = None,
     ) -> torch.Tensor:
-        """Compute confidence scores for query samples.
+        """Compute uncertainty scores for query samples.
 
         This method supports two usage modes:
 
@@ -390,7 +390,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         Returns
         -------
         torch.Tensor
-            1-D tensor of shape `(N,)` with confidence scores.
+            1-D tensor of shape `(N,)` with uncertainty scores.
             Low values indicate likely inliers, high values indicate likely outliers.
         """
         # Validate parameter combinations
@@ -430,9 +430,9 @@ class EmbeddingScore(ConfidenceScore, ABC):
             return self._score_embeddings(embeddings)
 
     def _score_embeddings(self, X: torch.Tensor) -> torch.Tensor:
-        """Compute confidence scores based on query embeddings.
+        """Compute uncertainty scores based on query embeddings.
 
-        This method should be implemented by subclasses to compute confidence
+        This method should be implemented by subclasses to compute uncertainty
         scores based on the query embeddings `X`. The base class does not
         implement any specific scoring logic, as this will depend on the
         particular method (e.g., k-nearest neighbors, PyOD scores, etc.).
@@ -445,7 +445,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         Returns
         -------
         torch.Tensor
-            A `torch.Tensor` with confidence scores for each query sample.
+            A `torch.Tensor` with uncertainty scores for each query sample.
             Low scores indicate likely inliers, high scores indicate likely outliers.
         """
         raise NotImplementedError(
@@ -462,7 +462,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         outdir: Path | None = None,
         prefix: str | None = None,
     ) -> dict[str, torch.Tensor]:
-        """Select samples for prediction based on their confidence score.
+        """Select samples for prediction based on their uncertainty score.
 
         This method supports two usage modes:
 
@@ -472,7 +472,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
 
         You must use either embeddings (X) OR model+loader, but not both.
 
-        Samples are selected based on their confidence score relative to a
+        Samples are selected based on their uncertainty score relative to a
         threshold. Samples with scores lower than the threshold are selected,
         while samples with scores higher than the threshold are excluded. The
         threshold should be calibrated beforehand (e.g., on validation samples).
@@ -511,7 +511,7 @@ class EmbeddingScore(ConfidenceScore, ABC):
         Returns
         -------
         dict[str, torch.Tensor]
-            A dict with keys `'score'` (confidence scores) and `'selected'`
+            A dict with keys `'score'` (uncertainty scores) and `'selected'`
             (boolean mask where `True` means the sample is selected).
         """
         if self.train_required:

--- a/seapig/scores/knn.py
+++ b/seapig/scores/knn.py
@@ -1,4 +1,4 @@
-"""KNN-based confidence scores."""
+"""KNN-based uncertainty scores."""
 
 import warnings
 from abc import ABC, abstractmethod
@@ -18,11 +18,11 @@ __all__ = ["KNNScore", "EuclideanScore", "CosineScore", "MahalanobisScore"]
 
 
 class KNNScore(EmbeddingScore, ABC):
-    """Abstract base class for KNN distance-based confidence scores.
+    """Abstract base class for KNN distance-based uncertainty scores.
 
-    Computes distance-based confidence scores where low scores indicate samples
-    similar to the training distribution (likely inliers) and high scores indicate
-    samples deviating from the training distribution (likely outliers).
+    Computes distance-based uncertainty scores where low scores indicate samples
+    similar to the training distribution (low uncertainty) and high scores indicate
+    samples deviating from the training distribution (high uncertainty).
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ class KNNScore(EmbeddingScore, ABC):
         prefix: str | None = None,
         q: bool | float = False,
     ) -> None:
-        """Train a confidence score based on sample embeddings.
+        """Train a uncertainty score based on sample embeddings.
 
         This method supports two usage modes:
 
@@ -170,11 +170,11 @@ class KNNScore(EmbeddingScore, ABC):
 
     @override
     def _score_embeddings(self, X: torch.Tensor) -> torch.Tensor:
-        """Compute a confidence score based on sample embeddings.
+        """Compute an uncertainty score based on sample embeddings.
 
-        Returns scores where low values indicate likely inliers (samples similar
-        to training) and high values indicate likely outliers (samples deviating
-        from training).
+        Returns scores where low values indicate samples similar
+        to the training data (low uncertainty) and high values indicate samples deviating
+        from training data (high uncertainty).
 
         Parameters
         ----------
@@ -371,9 +371,9 @@ class KNNScore(EmbeddingScore, ABC):
 class EuclideanScore(KNNScore):
     """Returns the KNN-distance based on the Euclidean distance to the nearest samples.
 
-    Computes Euclidean distance-based confidence scores where low scores indicate
-    samples similar to the training distribution (likely inliers) and high scores
-    indicate samples deviating from the training distribution (likely outliers).
+    Computes Euclidean distance-based uncertainty scores where low scores indicate
+    samples similar to the training distribution (low uncertainty) and high scores
+    indicate samples deviating from the training distribution (high uncertainty).
 
     Parameters
     ----------
@@ -435,9 +435,9 @@ class EuclideanScore(KNNScore):
 class CosineScore(KNNScore):
     """Returns the KNN-distance based on the cosine distance to the nearest samples.
 
-    Computes cosine distance-based confidence scores where low scores indicate
-    samples similar to the training distribution (likely inliers) and high scores
-    indicate samples deviating from the training distribution (likely outliers).
+    Computes cosine distance-based uncertainty scores where low scores indicate
+    samples similar to the training distribution (low uncertainty) and high scores
+    indicate samples deviating from the training distribution (high uncertainty).
 
     The cosine distance is computed as `(1 - cosine_similarity)`, with a range
     of `[0, 2]` where `0` indicates identical vectors, `1` indicates orthogonal
@@ -503,9 +503,9 @@ class CosineScore(KNNScore):
 class MahalanobisScore(KNNScore):
     """Returns the Mahalanobis distance to the training samples distribution.
 
-    Computes Mahalanobis distance-based confidence scores where low scores indicate
-    samples similar to the training distribution (likely inliers) and high scores
-    indicate samples deviating from the training distribution (likely outliers).
+    Computes Mahalanobis distance-based uncertainty scores where low scores indicate
+    samples similar to the training distribution (low uncertainty) and high scores
+    indicate samples deviating from the training distribution (high uncertainty).
 
     The Mahalanobis distance accounts for correlations in the training data by
     whitening the embeddings with the Cholesky factor of the training covariance

--- a/seapig/scores/logits.py
+++ b/seapig/scores/logits.py
@@ -1,5 +1,5 @@
 # python
-"""Logit-derived confidence score base class.
+"""Logit-derived uncertainty score base class.
 
 Provides helpers for scores computed from model logits (pre-softmax
 outputs): stable softmax, entropy, margin, max-logit, and
@@ -17,12 +17,12 @@ import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from typing_extensions import override
 
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 from seapig.utils.progress import track
 
 
-class LogitScore(ConfidenceScore, abc.ABC):
-    """Base class for logit-based confidence scores.
+class LogitScore(UncertaintyScore, abc.ABC):
+    """Base class for logit-based uncertainty scores.
 
     Supports multiclass, binary (single/two-logit), and multilabel tasks.
     Handles temperature fitting and input normalization for all cases.
@@ -81,7 +81,7 @@ class LogitScore(ConfidenceScore, abc.ABC):
 
     @staticmethod
     def _check_model(model: torch.nn.Module) -> None:
-        """Check if the model is compatible with logits-based confidence scores.
+        """Check if the model is compatible with logits-based uncertainty scores.
 
         Parameters
         ----------
@@ -200,7 +200,7 @@ class LogitScore(ConfidenceScore, abc.ABC):
 
     @abc.abstractmethod
     def score(self, query_logits: torch.Tensor) -> torch.Tensor:
-        """Compute confidence scores for query logits.
+        """Compute uncertainty scores for query logits.
 
         Parameters
         ----------
@@ -210,12 +210,12 @@ class LogitScore(ConfidenceScore, abc.ABC):
         Returns
         -------
         torch.Tensor
-            1-D tensor of shape `(M,)`. Lower values indicate higher confidence.
+            1-D tensor of shape `(M,)`. Lower values indicate lower uncertainty.
         """
         raise NotImplementedError()
 
     def select(self, query_logits: torch.Tensor) -> dict[str, torch.Tensor]:
-        """Select samples for prediction based on their confidence score.
+        """Select samples for prediction based on their uncertainty score.
 
         Samples with scores lower than the threshold are selected for prediction,
         while samples with scores higher than the threshold are excluded.
@@ -228,7 +228,7 @@ class LogitScore(ConfidenceScore, abc.ABC):
         Returns
         -------
         dict[str, torch.Tensor]
-            A dict with keys `'score'` (confidence scores) and `'selected'`
+            A dict with keys `'score'` (uncertainty scores) and `'selected'`
             (boolean mask where `True` means the sample is selected).
         """
         if self.threshold is None:
@@ -523,10 +523,10 @@ class LogitScore(ConfidenceScore, abc.ABC):
 
 
 class SoftmaxScore(LogitScore):
-    """Maximum softmax probability confidence score.
+    """Maximum softmax probability uncertainty score.
 
     Supports multiclass, binary (single/two-logit), and multilabel tasks.
-    Higher maximum softmax probability indicates higher confidence (lower score).
+    Higher maximum softmax probability indicates higher uncertainty (higher score).
 
     Parameters
     ----------
@@ -562,17 +562,22 @@ class SoftmaxScore(LogitScore):
 
     @override
     def score(self, query_logits: torch.Tensor) -> torch.Tensor:
-        """Compute task-aware softmax-based confidence score.
+        """Compute task-aware softmax-based uncertainty score.
 
         For multiclass: -max softmax probability.
         For binary single-logit: -sigmoid(|logit|).
         For binary two-logit: -max softmax probability.
         For multilabel: -min(max(p, 1-p)), where p = sigmoid(logit).
 
+        Parameters
+        ----------
+        query_logits : torch.Tensor
+            Logits for samples to score. Shape depends on task.
+
         Returns
         -------
         torch.Tensor
-            1-D tensor of shape (M,) with scores (lower == more confident).
+            1-D tensor of shape `(M,)`. Lower values indicate lower uncertainty.
         """
         T = 1.0 if self.temperature is None else float(self.temperature)
         task = self.task
@@ -596,11 +601,10 @@ class SoftmaxScore(LogitScore):
 
 
 class EnergyScore(LogitScore):
-    """Energy-based confidence score.
+    """Energy-based uncertainty score.
 
-    Computes the free energy of the logit distribution. Lower energy (more
-    negative) indicates higher confidence. Supports multiclass, binary, and
-    multilabel tasks.
+    Computes the free energy of the logit distribution. Lower energy indicates
+    lower uncertainty. Supports multiclass, binary, and multilabel tasks.
 
     Parameters
     ----------
@@ -638,36 +642,39 @@ class EnergyScore(LogitScore):
     def score(self, query_logits: torch.Tensor) -> torch.Tensor:
         """Compute energy for query logits (task-aware).
 
-        Returns a 1-D tensor of shape (M,) where lower values are more
-        confident.
+        Parameters
+        ----------
+        query_logits : torch.Tensor
+            Logits for samples to score. Shape depends on task.
+
+        Returns
+        -------
+        torch.Tensor
+            1-D tensor of shape `(M,)`. Lower values indicate lower uncertainty.
         """
         T = 1.0 if self.temperature is None else float(self.temperature)
         task = self.task
         logits = query_logits
         if task == "multiclass":
-            # -T * logsumexp(logits / T)
             return -(logits / T).logsumexp(dim=1) * T
         elif task == "binary":
             if self._is_binary_single_logit(logits):
-                # we take abs(logits) to ensure energy is low for confident
-                # predictions in  either direction
                 return -T * F.softplus(torch.abs(logits) / T)
             else:
                 # two-logit: same as multiclass
                 return -(logits / T).logsumexp(dim=1) * T
         elif task == "multilabel":
-            # Sum of per-label free energies: -T * sum(softplus(logit/T))
             return -T * F.softplus(logits / T).sum(dim=1)
         else:
             raise ValueError(f"Unknown task: {task}")
 
 
 class MarginScore(LogitScore):
-    """Top-two margin confidence score.
+    """Top-two margin uncertainty score.
 
     Computes the difference between the top-two logits. A larger margin
-    indicates higher confidence (lower score). Supports multiclass,
-    binary (single/two-logit), and multilabel tasks.
+    indicates lower uncertainty. Supports multiclass, binary (single/two-logit),
+    and multilabel tasks.
 
     Parameters
     ----------
@@ -703,17 +710,22 @@ class MarginScore(LogitScore):
 
     @override
     def score(self, query_logits: torch.Tensor) -> torch.Tensor:
-        """Compute task-aware margin-based confidence score.
+        """Compute task-aware margin-based uncertainty score.
 
         For multiclass: negative top-two margin.
         For binary single-logit: negative absolute logit.
         For binary two-logit: negative top-two margin.
         For multilabel: negative min(|logit|).
 
+        Parameters
+        ----------
+        query_logits : torch.Tensor
+            Logits for samples to score. Shape depends on task.
+
         Returns
         -------
         torch.Tensor
-            1-D tensor of shape (M,) with scores (lower == more confident).
+            1-D tensor of shape `(M,)`. Lower values indicate lower uncertainty.
         """
         T = 1.0 if self.temperature is None else float(self.temperature)
         task = self.task
@@ -738,10 +750,10 @@ class MarginScore(LogitScore):
 
 
 class EntropyScore(LogitScore):
-    """Entropy-based confidence score.
+    """Entropy-based uncertainty score.
 
-    Computes the predictive entropy of the output distribution. Higher entropy
-    indicates higher uncertainty (higher score). Supports multiclass, binary,
+    Computes the predictive entropy of the output distribution. Lower entropy
+    indicates lower uncertainty. Supports multiclass, binary,
     and multilabel tasks.
 
     Parameters
@@ -780,10 +792,15 @@ class EntropyScore(LogitScore):
     def score(self, query_logits: torch.Tensor) -> torch.Tensor:
         """Compute predictive entropy for each sample (task-aware).
 
+        Parameters
+        ----------
+        query_logits : torch.Tensor
+            Logits for samples to score. Shape depends on task.
+
         Returns
         -------
         torch.Tensor
-            1-D tensor of shape (M,) with entropy scores (lower == more confident).
+            1-D tensor of shape `(M,)`. Lower values indicate lower uncertainty.
         """
         T = 1.0 if self.temperature is None else float(self.temperature)
         task = self.task

--- a/seapig/scores/pca.py
+++ b/seapig/scores/pca.py
@@ -1,4 +1,4 @@
-"""PCA based dimensionality reduction and confidence scoring."""
+"""PCA based dimensionality reduction and uncertainty scoring."""
 
 from pathlib import Path
 
@@ -11,9 +11,9 @@ from seapig.scores.utils import TensorPCA
 
 
 class PCAScore(EmbeddingScore):
-    """Returns confidence scores based on PCA reconstruction errors.
+    """Returns uncertainty scores based on PCA reconstruction errors.
 
-    Computes reconstruction error-based confidence scores where low scores indicate
+    Computes reconstruction error-based uncertainty scores where low scores indicate
     samples that can be well-reconstructed from principal components (likely inliers)
     and high scores indicate samples with large reconstruction errors (likely outliers).
 
@@ -65,7 +65,7 @@ class PCAScore(EmbeddingScore):
         prefix: str | None = None,
         q: bool | float = False,
     ) -> None:
-        """Train a confidence score based on sample embeddings.
+        """Train an uncertainty score based on sample embeddings.
 
         This method supports two usage modes:
 
@@ -143,11 +143,11 @@ class PCAScore(EmbeddingScore):
 
     @override
     def _score_embeddings(self, X: torch.Tensor) -> torch.Tensor:
-        """Compute a confidence score based on sample embeddings.
+        """Compute an uncertainty score based on sample embeddings.
 
         Returns reconstruction error scores where low values indicate samples that
-        can be well-reconstructed (likely inliers) and high values indicate samples
-        with large reconstruction errors (likely outliers).
+        can be well-reconstructed (low uncertainty) and high values indicate samples
+        with large reconstruction errors (high uncertainty).
 
         Parameters
         ----------

--- a/seapig/scores/pyod.py
+++ b/seapig/scores/pyod.py
@@ -1,4 +1,4 @@
-"""Confidence score based on an arbitrary PyOD model."""
+"""Uncertainty score based on an arbitrary PyOD model."""
 
 from pathlib import Path
 
@@ -18,11 +18,11 @@ except ImportError:  # pragma: no cover
 
 
 class PyODScore(EmbeddingScore):
-    """Confidence scores based on detectors supplied by PyOD.
+    """Uncertainty scores based on detectors supplied by PyOD.
 
     Computes outlier scores using PyOD detectors where low scores indicate samples
-    similar to the training distribution (likely inliers) and high scores indicate
-    samples deviating from the training distribution (likely outliers).
+    similar to the training distribution (low uncertainty) and high scores indicate
+    samples deviating from the training distribution (high uncertainty).
 
     Parameters
     ----------
@@ -69,7 +69,7 @@ class PyODScore(EmbeddingScore):
         prefix: str | None = None,
         q: bool | float = False,
     ) -> None:
-        """Train a confidence score based on sample embeddings.
+        """Train an uncertainty score based on sample embeddings.
 
         This method supports two usage modes:
 
@@ -157,11 +157,11 @@ class PyODScore(EmbeddingScore):
     @override
     @torch.inference_mode()
     def _score_embeddings(self, X: torch.Tensor) -> torch.Tensor:
-        """Compute a confidence score based on sample embeddings.
+        """Compute an uncertainty score based on sample embeddings.
 
-        Returns outlier scores where low values indicate likely inliers (samples
-        similar to training) and high values indicate likely outliers (samples
-        deviating from training).
+        Returns uncertainty scores where low values indicate samples
+        similar to the training distribution (low uncertainty) and high values indicate
+        samples deviating from the training distribution (high uncertainty).
 
         Parameters
         ----------

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,10 +5,10 @@ import pytest
 import torch
 
 from seapig.scores import EuclideanScore, RandomScore
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 
 
-class Dummy(ConfidenceScore):
+class Dummy(UncertaintyScore):
     def fit(
         self,
         X: torch.Tensor | None = None,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,10 +7,10 @@ from torchmetrics import Accuracy, MetricCollection
 from typing_extensions import override
 
 from seapig import RiskCoverageMetric, SelectiveInferenceTask
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 
 
-class DummyScore(ConfidenceScore):
+class DummyScore(UncertaintyScore):
     """Minimal duck-typed score with select()."""
 
     def select(self, x: torch.Tensor) -> dict[str, torch.Tensor]:

--- a/tests/test_selective_integration.py
+++ b/tests/test_selective_integration.py
@@ -10,7 +10,7 @@ from torchmetrics import Accuracy
 
 from seapig import RiskCoverageMetric
 from seapig.model import SelectiveInferenceTask
-from seapig.scores.base import ConfidenceScore
+from seapig.scores.base import UncertaintyScore
 
 
 class DummyTask(LightningModule):
@@ -30,11 +30,11 @@ class DummyTask(LightningModule):
         return x
 
 
-class FlagScore(ConfidenceScore):
+class FlagScore(UncertaintyScore):
     """Select if the first element of embedding equals 1.
 
     Minimal implementation for tests: implements the abstract `fit` and
-    `score` methods from ConfidenceScore as no-ops / simple stubs so the
+    `score` methods from UncertaintyScore as no-ops / simple stubs so the
     class can be instantiated. The test's selection logic still relies on
     `select()` which inspects embeddings directly.
     """


### PR DESCRIPTION
Since the majority of scores indicate low uncertainty/high confidence with low values and vice-versa it is less confusing to refer to them as uncertainty scores. Lower scores are thus less uncertain and selected for prediction, higher scores are rejected from prediction - thus the renaming to uncertainty scores to reduce friction.